### PR TITLE
Full standings

### DIFF
--- a/fpl/classic_league.py
+++ b/fpl/classic_league.py
@@ -1,5 +1,6 @@
 import json
 import requests
+import itertools 
 
 API_BASE_URL = "https://fantasy.premierleague.com/drf/"
 
@@ -38,7 +39,7 @@ class ClassicLeague(object):
         return requests.get("{}leagues-classic-standings/{}".format(
             API_BASE_URL, self.id)).json()
             
-    def _standings():
+    def _standings(self):
         """Returns league standings for all teams."""
         standings = []
         # iterate through all available pages

--- a/fpl/classic_league.py
+++ b/fpl/classic_league.py
@@ -44,7 +44,8 @@ class ClassicLeague(object):
         standings = []
         # iterate through all available pages
         for page in itertools.count(start=1):
-            url = "{}leagues-classic-standings/{}?ls-page={}".format(API_BASE_URL, self.id, page)
+            url = "{}leagues-classic-standings/{}?ls-page={}".format(
+                API_BASE_URL, self.id, page)
             page_results = requests.get(url).json()['standings']['results']
             # check if page exists 
             if page_results:

--- a/fpl/classic_league.py
+++ b/fpl/classic_league.py
@@ -22,7 +22,7 @@ class ClassicLeague(object):
         #: The gameweek the league started in.
         self.started = self._league["start_event"]
 
-        self.standings = self._information["standings"]["results"]
+        self.standings = self._standings() 
         """
         A list (of dictionaries) containing information about the league's
         standings.
@@ -37,6 +37,19 @@ class ClassicLeague(object):
         """Returns information about the given league."""
         return requests.get("{}leagues-classic-standings/{}".format(
             API_BASE_URL, self.id)).json()
+            
+    def _standings():
+        """Returns league standings for all teams."""
+        standings = []
+        # iterate through all available pages
+        for page in itertools.count(start=1):
+            url = "{}leagues-classic-standings/{}?ls-page={}".format(API_BASE_URL, self.id, page)
+            page_results = requests.get(url).json()['standings']['results']
+            # check if page exists 
+            if page_results:
+                standings.extend(page_results)
+            else:
+                return standings 
 
     def __str__(self):
         return "{} - {}".format(self.name, self.id)


### PR DESCRIPTION
Great project!

Currently the ClassicLeague object only returns the standings for the top 50 teams in a league (first page of results). I have added a new method to return the standings for all teams in the league.

I'm not sure if the current implementation was intentional, to avoid the potential for making thousands of requests and persisting very large lists for massive leagues (e.g. "global" leaderboard). In any case this could be controlled by parameterizing the number of teams you want to return, whilst the size issue alone could be mitigated by returning a generator instead of a list.

Happy to modify the pull request if you like the change but want a different approach 