### PR TITLE
H2H fixtures/results with authentication 

### DIFF
--- a/fpl/h2h_league.py
+++ b/fpl/h2h_league.py
@@ -7,7 +7,7 @@ class H2HLeague(object):
     """
     A class representing a h2h league in the Fantasy Premier League.
     """
-    def __init__(self, league_id):        
+    def __init__(self, league_id):
         self.id = league_id
         self._information = self._information()
         self._league = self._information["league"]
@@ -46,7 +46,7 @@ class H2HLeague(object):
     def _information(self):
         """Returns information about the given league."""
         return requests.get("{}leagues-h2h-standings/{}".format(
-            API_BASE_URL, self.id)).json()    
+            API_BASE_URL, self.id)).json()
 
     def __str__(self):
         return "{} - {}".format(self.name, self.id)


### PR DESCRIPTION
Objective here is to return all results/fixtures for H2H leagues, this is what we find in the "matches" tab of the league page (next to "standings").

I have tried to implement the pagination in a consistent way with my other pull request. 

One important thing to note it that we must be "logged in" to have access to this data, and so require FPL authentication. This is very strange and seems like a quirk of the FPL API because:
1. We are not required to do this for any other aspect of the classic/H2H leagues (that I am aware of) 
2. We are not restricted to "matches" for the logged in user, we simply need to be logged in to *any* user to have access to "matches" for all H2H leagues. 

Whilst this is bizarre it does mean that to enable this functionality the user is not required to provide their own login credentials, and so I have simply hard-coded some static credentials for a dummy account. 

I have also separated the `login_session` function from the `H2HLeague` class as it does not belong to it and can have other uses, for example: allow people to login to their own user and return a "live view" of their team, but in this case the function should be moved elsewhere. 

As in my other pull request I am happy to make any changes, I am just interested in having this feature available! 