### PR TITLE
Add the missing internal package (fpl.models) to the setup.py - version bump to 0.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 
 setup(
     name="fpl",
-    version="0.5.2",
-    packages=["fpl"],
+    version="0.5.3",
+    packages=["fpl", "fpl.models"],
     description="A Python wrapper for the Fantasy Premier League API",
     url="https://github.com/amosbastian/fpl",
     author="amosbastian",


### PR DESCRIPTION
This change will fix the problem on pypi installs. Later on,
 it can be replaced with find_packages() helper.