### PR TITLE
Add FDR() and get_points_against() functions to FPL class

### DIFF
--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -221,8 +221,8 @@ class FPL():
                 team = {k: v for k, v in vars(team).items()
                         if not k.startswith("_")}
 
-                database_teams.update({"team_id": team["team_id"]},
-                                      team, upsert=True)
+                database_teams.replace_one(
+                    {"team_id": team["team_id"]}, team, upsert=True)
 
         def update_players():
             """Updates all players of the Fantasy Premier League."""
@@ -233,8 +233,8 @@ class FPL():
                 player = {k: v for k, v in vars(player).items()
                           if not k.startswith("_")}
 
-                database_players.update({"player_id": player["player_id"]},
-                                        player, upsert=True)
+                database_players.replace_one(
+                    {"player_id": player["player_id"]}, player, upsert=True)
 
         update_teams()
         update_players()
@@ -244,7 +244,10 @@ class FPL():
         all teams in the Premier League, split by position.
         """
         if not players:
-            players = self.get_players()
+            players = []
+            for player in self.get_players():
+                players.append({k: v for k, v in vars(player).items()
+                               if not k.startswith("_")})
 
         points_against = {}
 

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -47,3 +47,17 @@ def chip_converter(chip):
         "freehit": "FH"
     }
     return chip_map[chip]
+
+
+def scale(value, upper, lower, min_, max_):
+    """Scales value between upper and lower values, depending on the given
+    minimun and maximum value.
+    """
+    numerator = ((lower - upper) * float((value - min_)))
+    denominator = float((max_ - min_))
+    return numerator / denominator + upper
+
+
+def average(iterable):
+    """Returns the average value of the iterable."""
+    return sum(iterable) / float(len(iterable))

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -85,5 +85,10 @@ class FPLTest(unittest.TestCase):
         player = database.players.find_one({"player_id": 1})
         self.assertEqual(player["player_id"], 1)
 
+    def test_get_points_against(self):
+        points_against = self.test_get_points_against()
+        self.assertIsInstance(points_against, dict)
+        self.assertEqual(len(points_against), 20)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -86,9 +86,33 @@ class FPLTest(unittest.TestCase):
         self.assertEqual(player["player_id"], 1)
 
     def test_get_points_against(self):
-        points_against = self.test_get_points_against()
+        points_against = self.fpl.get_points_against()
         self.assertIsInstance(points_against, dict)
         self.assertEqual(len(points_against), 20)
+
+    def test_FDR(self):
+        def test_main(fdr):
+            self.assertIsInstance(fdr, dict)
+            self.assertEqual(len(fdr), 20)
+
+            location_extrema = {"H": [], "A": []}
+            for team, positions in fdr.items():
+                for location in positions.values():
+                    location_extrema["H"].append(location["H"])
+                    location_extrema["A"].append(location["A"])
+
+            self.assertEqual(max(location_extrema["H"]), 5.0)
+            self.assertEqual(min(location_extrema["H"]), 1.0)
+            self.assertEqual(max(location_extrema["A"]), 5.0)
+            self.assertEqual(min(location_extrema["A"]), 1.0)
+
+        def test_default():
+            fdr = self.fpl.FDR()
+            test_main(fdr)
+
+        def test_mongodb():
+            fdr = self.fpl.FDR(True)
+            test_main(fdr)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds the functions:

* `get_points_against()`, which returns a dictionary containing all the points a team concedes in Fantasy Premier League terms per position.
* `FDR()`, which returns a dictionary containing a scaled (between 1.0 and 5.0) fixture difficulty ranking for each team, per position and per location (home and away).