### PR TITLE
Add functionality for team fixtures

### DIFF
--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -236,8 +236,16 @@ class FPL():
                 database_players.replace_one(
                     {"player_id": player["player_id"]}, player, upsert=True)
 
+        def update_fdr():
+            """Updates the FDR of each team in the Fantasy Premier League."""
+            team_fdr = self.FDR(mongodb=True)
+            for team_name, fdr in team_fdr.items():
+                team = database.teams.update_one(
+                    {"name": team_name}, {"$set": {"FDR": fdr}}, upsert=True)
+
         update_teams()
         update_players()
+        update_fdr()
 
     def get_points_against(self, players=None):
         """Returns a dictionary containing the points scored against

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -27,6 +27,7 @@ import os
 import requests
 
 from .constants import API_URLS
+from datetime import datetime
 from .models.classic_league import ClassicLeague
 from .models.fixture import Fixture
 from .models.gameweek import Gameweek
@@ -214,6 +215,7 @@ class FPL():
 
         def update_teams():
             """Updates all teams of the Fantasy Premier League."""
+            print("{} - updating teams.".format(datetime.now()))
             database_teams = database.teams
             teams = FPL.get_teams()
 
@@ -226,6 +228,7 @@ class FPL():
 
         def update_players():
             """Updates all players of the Fantasy Premier League."""
+            print("{} - updating players.".format(datetime.now()))
             database_players = database.players
             players = FPL.get_players()
 
@@ -238,14 +241,36 @@ class FPL():
 
         def update_fdr():
             """Updates the FDR of each team in the Fantasy Premier League."""
+            print("{} - updating FDR.".format(datetime.now()))
             team_fdr = self.FDR(mongodb=True)
             for team_name, fdr in team_fdr.items():
                 team = database.teams.update_one(
                     {"name": team_name}, {"$set": {"FDR": fdr}}, upsert=True)
 
+        def update_fixtures():
+            """Updates the fixtures of each team, which includes the FDR of
+            that specific fixture.
+            """
+            print("{} - updating fixtures.".format(datetime.now()))
+            for team in database.teams.find():
+                # Find one player of each team and use them to get the fixtures
+                player = database.players.find_one({"team": team["name"]})
+                fixtures = player["fixtures"]
+                for fixture in fixtures:
+                    location = "H" if fixture["is_home"] else "A"
+                    opponent = database.teams.find_one(
+                        {"name": fixture["opponent_name"]})
+                    fdr = {position: difficulty[location]
+                           for position, difficulty in opponent["FDR"].items()}
+                    fixture["FDR"] = fdr
+
+                database.teams.update_one(
+                    team, {"$set": {"fixtures": fixtures}}, upsert=True)
+
         update_teams()
         update_players()
         update_fdr()
+        update_fixtures()
 
     def get_points_against(self, players=None):
         """Returns a dictionary containing the points scored against

--- a/fpl/models/team.py
+++ b/fpl/models/team.py
@@ -64,6 +64,14 @@ class Team():
                        if player["team_code"] == self.code]
         self.players = players
 
+    def get_fixtures(self):
+        """Sets the team's fixtures equal to that of one of its player's
+        fixtures."""
+        if not self.players:
+            self.get_players()
+        player = self.players[0]
+        self.fixtures = player.fixtures
+
     def _get_information(self):
         response = requests.get(API_URLS["teams"]).json()
         return response[self.team_id - 1]

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -81,6 +81,11 @@ class FPLTest(unittest.TestCase):
 
         teams = database.teams.find()
         self.assertEqual(teams.count(), 20)
+        team = database.teams.find_one({"team_id": 1})
+        self.assertIsInstance(team["fixtures"], list)
+        self.assertTrue("FDR" in team.keys())
+        self.assertTrue(len(team["fixtures"] > 0))
+        self.assertTrue("FDR" in team["fixtures"])
 
         player = database.players.find_one({"player_id": 1})
         self.assertEqual(player["player_id"], 1)

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -84,8 +84,8 @@ class FPLTest(unittest.TestCase):
         team = database.teams.find_one({"team_id": 1})
         self.assertIsInstance(team["fixtures"], list)
         self.assertTrue("FDR" in team.keys())
-        self.assertTrue(len(team["fixtures"] > 0))
-        self.assertTrue("FDR" in team["fixtures"])
+        self.assertTrue(len(team["fixtures"]) > 0)
+        self.assertTrue("FDR" in team["fixtures"][0].keys())
 
         player = database.players.find_one({"player_id": 1})
         self.assertEqual(player["player_id"], 1)

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -21,5 +21,10 @@ class TeamTest(unittest.TestCase):
         self.assertIsInstance(self.team.players, list)
         self.assertIsInstance(self.team.players[0], Player)
 
+    def test_get_fixtures(self):
+        self.team.get_fixtures()
+        self.assertIsInstance(self.team.fixtures, list)
+        self.assertTrue(len(self.team.fixtures) > 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds the functions

* `update_fdr()`, which updates a team's FDR
* `update_fixtures()`, which updates a team's fixtures, including the FDR of each fixture

to `FPL.update_mongodb() and adds the function

`get_fixtures()`, which gets a team's fixture

to the `Team` class.