### PR TITLE
Fix issue where users favourite team is returned as null.

### DIFF
--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -23,7 +23,7 @@ def team_converter(team_id):
         18: "Watford",
         19: "West Ham",
         20: "Wolves",
-	None: "None"
+	None: None
     }
     return team_map[team_id]
 

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -22,7 +22,8 @@ def team_converter(team_id):
         17: "Spurs",
         18: "Watford",
         19: "West Ham",
-        20: "Wolves"
+        20: "Wolves",
+	None: "None"
     }
     return team_map[team_id]
 


### PR DESCRIPTION
When users don't have a favourite team picked, None was being passed into the team_converter, causing a KeyError crash. Small fix to stop this. 