### PR TITLE
0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/_templates/
 .idea/
 .vscode/
 test.py
+test_pa.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: python
 
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - &mainstream_python 3.7
 
 install:
   - python setup.py install
 
 script:
-  - python -m unittest discover tests/
-
-services:
-  - mongodb
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+dist: xenial
+sudo: required
+
 python:
   - "3.6"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 
 python:
-  - "3.5"
   - "3.6"
-  - &mainstream_python 3.7
+  - "3.7"
 
 install:
   - python setup.py install

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -51,7 +51,7 @@ class FPL():
             assert response.status == 200
             return await response.json()
 
-    async def get_user(self, user_id, json=False):
+    async def get_user(self, user_id, return_json=False):
         """Returns a `User` object or JSON containing information about the
         user with the given `user_id`.
 
@@ -61,16 +61,21 @@ class FPL():
         url = API_URLS["user_cup"].format(user_id)
         user = await self._fetch(url)
 
-        if json:
+        if return_json:
             return user
         return User(user, session=session)
 
-    @staticmethod
-    def get_teams():
-        """Returns a list of `Team` objects of the teams currently
+    async def get_teams(self, return_json=False):
+        """Returns a list JSON or `Team` objects of the teams currently
         participating in the Premier League.
         """
-        return[Team(team_id) for team_id in range(1, 21)]
+        url = API_URLS["teams"]
+        teams = await self._fetch(url)
+
+        if return_json:
+            return teams
+
+        return[Team(team_information) for team_information in teams]
 
     @staticmethod
     def get_team(team_id):

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -307,7 +307,7 @@ class FPL():
         if return_json:
             return league
 
-        return ClassicLeague(league)
+        return ClassicLeague(league, session=self.session)
 
     async def get_h2h_league(self, league_id, return_json=False):
         """Returns a `H2HLeague` object with the given `league_id`.

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -53,7 +53,7 @@ class FPL():
         user with the given `user_id`.
 
         :param string user_id: A user's id
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
         url = API_URLS["user"].format(user_id)
         user = await fetch(self.session, url)
@@ -67,7 +67,7 @@ class FPL():
         participating in the Premier League.
 
         :param list team_ids: List containing the IDs of desired teams
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
         url = API_URLS["teams"]
         teams = await fetch(self.session, url)
@@ -86,7 +86,7 @@ class FPL():
         team with the given `team_id`.
 
         :param int team_id: A team's id
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
 
         .. code-block:: none
 
@@ -123,7 +123,7 @@ class FPL():
         """Returns a `PlayerSummary` or JSON object with the given `player_id`
 
         :param int player_id: A player's ID
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
         url = API_URLS["player"].format(player_id)
         player_summary = await fetch(self.session, url)
@@ -138,7 +138,7 @@ class FPL():
         `player_ids`
 
         :param list player_ids: A list of player IDs
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
         tasks = [asyncio.ensure_future(
                  fetch(self.session, API_URLS["player"].format(player_id)))
@@ -157,7 +157,9 @@ class FPL():
         """Returns a `Player` or JSON object with the given `player_id`.
 
         :param int player_id: A player's ID
-        :param boolean return_json: Flag for returning JSON
+        :param list players: A list of players
+        :param boolean include_summary: include player's summary if True
+        :param boolean return_json: return dict if True, otherwise Player
         """
         if not players:
             players = await fetch(self.session, API_URLS["players"])
@@ -181,7 +183,8 @@ class FPL():
         players with the given IDs.
 
         :param list player_ids: A list of player IDs
-        :param boolean return_json: Flag for returning JSON
+        :param boolean include_summary: include player's summary if True
+        :param boolean return_json: return dict if True, otherwise Player
         """
         players = await fetch(self.session, API_URLS["players"])
         if not player_ids:
@@ -200,7 +203,7 @@ class FPL():
 
         :param int fixture_id: The fixture's ID
         :param int gameweek: The gameweek the fixture is in
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
         if gameweek:
             fixtures = await fetch(
@@ -221,7 +224,7 @@ class FPL():
         gameweek.
 
         :param int gameweek: The gameweek the fixture is in
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
         if gameweek:
             fixtures = await fetch(
@@ -239,7 +242,7 @@ class FPL():
         or the gameweeks with the given IDs.
 
         :param list gameweek_ids: A list of gameweek IDs
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
 
         if not gameweek_ids:
@@ -269,7 +272,7 @@ class FPL():
         """Returns a `Gameweek` or JSON object of the specified gameweek.
 
         :param int gameweek_id: A gameweek's id
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
 
         static_gameweeks = await fetch(self.session, API_URLS["gameweeks"])
@@ -296,7 +299,7 @@ class FPL():
         `league_id`.
 
         :param string league_id: A league's id
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
         url = API_URLS["league_classic"].format(league_id)
         league = await fetch(self.session, url)
@@ -310,7 +313,7 @@ class FPL():
         """Returns a `H2HLeague` object with the given `league_id`.
 
         :param string league_id: A league's id
-        :param boolean return_json: Flag for returning JSON
+        :param boolean return_json: return dict if True, otherwise Player
         """
         url = API_URLS["league_h2h"].format(league_id)
         league = await fetch(self.session, url)

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -211,18 +211,23 @@ class FPL():
 
         return Fixture(fixture)
 
-    @staticmethod
-    def get_fixtures(gameweek=None):
+    async def get_fixtures(self, gameweek=None, return_json=False):
         """Returns all possible fixtures, or all fixtures of a specific
         gameweek.
+
+        :param int gameweek: The gameweek the fixture is in
+        :param boolean return_json: Flag for returning JSON
         """
         if gameweek:
-            response = requests.get(API_URLS["gameweek_fixtures"].format(
-                gameweek)).json()
+            fixtures = await self._fetch(API_URLS["gameweek_fixtures"].format(
+                gameweek))
         else:
-            response = requests.get(API_URLS["fixtures"]).json()
+            fixtures = await self._fetch(API_URLS["fixtures"])
 
-        return [Fixture(fixture) for fixture in response]
+        if return_json:
+            return fixtures
+
+        return [Fixture(fixture) for fixture in fixtures]
 
     @staticmethod
     def get_gameweeks():

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -55,7 +55,7 @@ class FPL():
         :param string user_id: A user's id
         :param boolean return_json: Flag for returning JSON
         """
-        url = API_URLS["user_cup"].format(user_id)
+        url = API_URLS["user"].format(user_id)
         user = await fetch(self.session, url)
 
         if return_json:

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -262,7 +262,8 @@ class FPL():
     async def get_gameweek(self, gameweek_id, return_json=False):
         """Returns a `Gameweek` or JSON object of the specified gameweek.
 
-        :param int gameweek_id: A gameweek's id.
+        :param int gameweek_id: A gameweek's id
+        :param boolean return_json: Flag for returning JSON
         """
 
         static_gameweeks = await self._fetch(API_URLS["gameweeks"])
@@ -278,19 +279,26 @@ class FPL():
 
         return Gameweek(live_gameweek)
 
-    @staticmethod
-    def game_settings():
+    async def game_settings(self):
         """Returns a dictionary containing the Fantasy Premier League's rules.
         """
-        return requests.get(API_URLS["settings"]).json()
+        settings = await self._fetch(API_URLS["settings"])
+        return settings
 
-    @staticmethod
-    def get_classic_league(league_id):
-        """Returns a `ClassicLeague` object with the given `league_id`.
+    async def get_classic_league(self, league_id, return_json=False):
+        """Returns a `ClassicLeague` or JSON  object with the given
+        `league_id`.
 
         :param string league_id: A league's id
+        :param boolean return_json: Flag for returning JSON
         """
-        return ClassicLeague(league_id)
+        url = API_URLS["league_classic"].format(league_id)
+        league = await self._fetch(url)
+
+        if return_json:
+            return league
+
+        return ClassicLeague(league)
 
     def get_h2h_league(self, league_id):
         """Returns a `H2HLeague` object with the given `league_id`.

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -46,6 +46,9 @@ session = aiohttp.ClientSession()
 
 class FPL():
     """The FPL class."""
+    def __init__(self):
+        self.session = session
+
     async def _fetch(self, url):
         async with session.get(url) as response:
             assert response.status == 200
@@ -300,12 +303,19 @@ class FPL():
 
         return ClassicLeague(league)
 
-    def get_h2h_league(self, league_id):
+    async def get_h2h_league(self, league_id, return_json=False):
         """Returns a `H2HLeague` object with the given `league_id`.
 
         :param string league_id: A league's id
+        :param boolean return_json: Flag for returning JSON
         """
-        return H2HLeague(league_id, session=session)
+        url = API_URLS["league_h2h"].format(league_id)
+        league = await self._fetch(url)
+
+        if return_json:
+            return league
+
+        return H2HLeague(league, session=self.session)
 
     def login(self, email=None, password=None):
         """Returns a requests session with FPL login authentication.
@@ -336,7 +346,7 @@ class FPL():
         if "Incorrect email or password" in response.text:
             raise ValueError("Incorrect email or password!")
 
-        session = session
+        self.session = session
 
     def update_mongodb(self):
         """Updates or creates a MongoDB database with the collection players

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -65,19 +65,23 @@ class FPL():
             return user
         return User(user, session=session)
 
-    async def get_teams(self, return_json=False):
+    async def get_teams(self, team_ids=[], return_json=False):
         """Returns a list JSON or `Team` objects of the teams currently
         participating in the Premier League.
 
+        :param list team_ids: List containing the IDs of desired teams
         :param boolean return_json: Flag for returning JSON
         """
         url = API_URLS["teams"]
         teams = await self._fetch(url)
 
+        if team_ids:
+            teams = [team for team in teams if team["id"] in team_ids]
+
         if return_json:
             return teams
 
-        return[Team(team_information) for team_information in teams]
+        return [Team(team_information) for team_information in teams]
 
     async def get_team(self, team_id, return_json=False):
         """Returns a `Team` object or JSON containing information about the

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -152,7 +152,8 @@ class FPL():
         return [PlayerSummary(player_summary)
                 for player_summary in player_summaries]
 
-    async def get_player(self, player_id, return_json=False):
+    async def get_player(self, player_id, include_summary=False,
+                         return_json=False):
         """Returns a `Player` or JSON object with the given `player_id`.
 
         :param int player_id: A player's ID
@@ -163,6 +164,11 @@ class FPL():
 
         player = next(player for player in players
                       if player["id"] == player_id)
+
+        if include_summary:
+            player_summary = await self.get_player_summary(
+                player["id"], return_json=True)
+            player.update(player_summary)
 
         if return_json:
             return player

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -384,6 +384,7 @@ class FPL():
                 points_against[opponent]["all"][location].append(points)
                 points_against[opponent][position][location].append(points)
 
+        # await self.session.close()
         return points_against
 
     async def FDR(self):

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -29,7 +29,6 @@ import os
 from datetime import datetime
 
 import aiohttp
-import requests
 
 from .constants import API_URLS
 from .models.classic_league import ClassicLeague

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -78,7 +78,8 @@ class FPL():
         if return_json:
             return teams
 
-        return [Team(team_information) for team_information in teams]
+        return [Team(team_information, self.session)
+                for team_information in teams]
 
     async def get_team(self, team_id, return_json=False):
         """Returns a `Team` object or JSON containing information about the
@@ -116,7 +117,7 @@ class FPL():
         if return_json:
             return teams[team_id + 1]
 
-        return Team(teams[team_id + 1])
+        return Team(teams[team_id + 1], self.session)
 
     async def get_player_summary(self, player_id, return_json=False):
         """Returns a `PlayerSummary` or JSON object with the given `player_id`

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -41,12 +41,10 @@ from .models.team import Team
 from .models.user import User
 from .utils import average, fetch, position_converter, scale, team_converter
 
-session = aiohttp.ClientSession()
-
 
 class FPL():
     """The FPL class."""
-    def __init__(self):
+    def __init__(self, session):
         self.session = session
 
     async def get_user(self, user_id, return_json=False):
@@ -481,3 +479,6 @@ class FPL():
         fdr = calculate_fdr(average_points, extrema)
 
         return fdr
+
+    async def _close(self):
+        await self.session.lose()

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -259,13 +259,24 @@ class FPL():
 
         return [Gameweek(gameweek) for gameweek in live_gameweeks]
 
-    @staticmethod
-    def get_gameweek(gameweek_id):
-        """Returns a `Gameweek` object of the specified gameweek.
+    async def get_gameweek(self, gameweek_id, return_json=False):
+        """Returns a `Gameweek` or JSON object of the specified gameweek.
 
         :param int gameweek_id: A gameweek's id.
         """
-        return Gameweek(gameweek_id)
+
+        static_gameweeks = await self._fetch(API_URLS["gameweeks"])
+        static_gameweek = next(gameweek for gameweek in static_gameweeks if
+                               gameweek["id"] == gameweek_id)
+        live_gameweek = await self._fetch(API_URLS["gameweek_live"].format(
+            gameweek_id))
+
+        live_gameweek.update(static_gameweek)
+
+        if return_json:
+            return live_gameweek
+
+        return Gameweek(live_gameweek)
 
     @staticmethod
     def game_settings():

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -56,7 +56,7 @@ class FPL():
         user with the given `user_id`.
 
         :param string user_id: A user's id
-        :param boolean json: Flag for returning JSON or User object
+        :param boolean return_json: Flag for returning JSON
         """
         url = API_URLS["user_cup"].format(user_id)
         user = await self._fetch(url)
@@ -68,6 +68,8 @@ class FPL():
     async def get_teams(self, return_json=False):
         """Returns a list JSON or `Team` objects of the teams currently
         participating in the Premier League.
+
+        :param boolean return_json: Flag for returning JSON
         """
         url = API_URLS["teams"]
         teams = await self._fetch(url)
@@ -77,12 +79,12 @@ class FPL():
 
         return[Team(team_information) for team_information in teams]
 
-    @staticmethod
-    def get_team(team_id):
-        """Returns a `Team` object containing information about the team with
-        the given `team_id`.
+    async def get_team(self, team_id, return_json=False):
+        """Returns a `Team` object or JSON containing information about the
+        team with the given `team_id`.
 
         :param int team_id: A team's id
+        :param boolean return_json: Flag for returning JSON
 
         .. code-block:: none
 
@@ -107,7 +109,13 @@ class FPL():
             19 - West Ham
             20 - Wolves
         """
-        return Team(team_id)
+        url = API_URLS["teams"]
+        teams = await self._fetch(url)
+
+        if return_json:
+            return teams[team_id + 1]
+
+        return Team(teams[team_id + 1])
 
     @staticmethod
     def get_player(player_id):

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -190,19 +190,26 @@ class FPL():
 
         return [Player(player) for player in players]
 
-    @staticmethod
-    def get_fixture(fixture_id, gameweek=None):
-        """Returns the fixture with the given ID."""
-        if gameweek:
-            response = requests.get(API_URLS["gameweek_fixtures"].format(
-                gameweek)).json()
-        else:
-            response = requests.get(API_URLS["fixtures"]).json()
+    async def get_fixture(self, fixture_id, gameweek=None, return_json=False):
+        """Returns the specific fixture with the given ID.
 
-        for fixture in response:
-            if fixture["id"] == fixture_id:
-                return Fixture(fixture)
-        return []
+        :param int fixture_id: The fixture's ID
+        :param int gameweek: The gameweek the fixture is in
+        :param boolean return_json: Flag for returning JSON
+        """
+        if gameweek:
+            fixtures = await self._fetch(API_URLS["gameweek_fixtures"].format(
+                gameweek))
+        else:
+            fixtures = await self._fetch(API_URLS["fixtures"])
+
+        fixture = next(fixture for fixture in fixtures
+                       if fixture["id"] == fixture_id)
+
+        if return_json:
+            return fixture
+
+        return Fixture(fixture)
 
     @staticmethod
     def get_fixtures(gameweek=None):

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -51,7 +51,7 @@ class FPL():
         user with the given `user_id`.
 
         :param string user_id: A user's id
-        :param boolean return_json: return dict if True, otherwise Player
+        :param boolean return_json: return dict if True, otherwise User
         """
         url = API_URLS["user"].format(user_id)
         user = await fetch(self.session, url)
@@ -65,7 +65,7 @@ class FPL():
         participating in the Premier League.
 
         :param list team_ids: List containing the IDs of desired teams
-        :param boolean return_json: return dict if True, otherwise Player
+        :param boolean return_json: return dict if True, otherwise Team
         """
         url = API_URLS["teams"]
         teams = await fetch(self.session, url)
@@ -200,7 +200,7 @@ class FPL():
         """Returns the fixture with the given `fixture_id`.
 
         :param int fixture_id: The fixture's ID
-        :param boolean return_json: return dict if True, otherwise Player
+        :param boolean return_json: return dict if True, otherwise Fixture
         """
         fixtures = await fetch(self.session, API_URLS["fixtures"])
 
@@ -285,7 +285,7 @@ class FPL():
         """Returns a `Gameweek` or JSON object of the specified gameweek.
 
         :param int gameweek_id: A gameweek's id
-        :param boolean return_json: return dict if True, otherwise Player
+        :param boolean return_json: return dict if True, otherwise Gameweek
         """
 
         static_gameweeks = await fetch(self.session, API_URLS["gameweeks"])
@@ -307,7 +307,7 @@ class FPL():
         or the gameweeks with the given IDs.
 
         :param list gameweek_ids: A list of gameweek IDs
-        :param boolean return_json: return dict if True, otherwise Player
+        :param boolean return_json: return dict if True, otherwise Gameweek
         """
 
         if not gameweek_ids:
@@ -331,7 +331,7 @@ class FPL():
         `league_id`.
 
         :param string league_id: A league's id
-        :param boolean return_json: return dict if True, otherwise Player
+        :param boolean return_json: return dict if True, otherwise ClassicLeague
         """
         url = API_URLS["league_classic"].format(league_id)
         league = await fetch(self.session, url)
@@ -345,7 +345,7 @@ class FPL():
         """Returns a `H2HLeague` object with the given `league_id`.
 
         :param string league_id: A league's id
-        :param boolean return_json: return dict if True, otherwise Player
+        :param boolean return_json: return dict if True, otherwise H2HLeague
         """
         url = API_URLS["league_h2h"].format(league_id)
         league = await fetch(self.session, url)

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -386,7 +386,6 @@ class FPL():
                 points_against[opponent]["all"][location].append(points)
                 points_against[opponent][position][location].append(points)
 
-        await self.session.close()
         return points_against
 
     async def FDR(self):

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -390,8 +390,6 @@ class FPL():
         """Creates a new Fixture Difficulty Ranking (FDR) based on the amount
         of points each team concedes in Fantasy Premier League terms.
         """
-        players = self.get_players()
-
         def average_points_against(points_against):
             """Averages the points scored against all teams per position."""
             for team, positions in points_against.items():
@@ -440,7 +438,7 @@ class FPL():
 
             return average_points
 
-        points_against = self.get_points_against(players)
+        points_against = await self.get_points_against()
         average_points = average_points_against(points_against)
         extrema = get_extrema(average_points)
         fdr = calculate_fdr(average_points, extrema)

--- a/fpl/models/classic_league.py
+++ b/fpl/models/classic_league.py
@@ -6,14 +6,12 @@ from ..constants import API_URLS
 
 class ClassicLeague():
     """A class representing a classic league in the Fantasy Premier League."""
-    def __init__(self, league_id):
-        self.league_id = league_id
-        self._information = self._get_information()
-        self._league = self._information["league"]
+    def __init__(self, league_information):
+        self._league = league_information["league"]
+        self.id = self._league["id"]
 
         #: A dictionary containing information about new entries to the league.
-        self.new_entries = self._information["new_entries"]
-
+        self.new_entries = league_information["new_entries"]
         #: The name of the league.
         self.name = self._league["name"]
         #: The shortname of the league.
@@ -42,10 +40,6 @@ class ClassicLeague():
         self.started = self._league["start_event"]
         #: The standings of the league.
         self.standings = None
-
-    def _get_information(self):
-        """Returns information about the given league."""
-        return requests.get(API_URLS["league_classic"].format(self.league_id)).json()
 
     def get_standings(self):
         """Returns league standings for all teams in the league."""

--- a/fpl/models/classic_league.py
+++ b/fpl/models/classic_league.py
@@ -1,60 +1,21 @@
-import itertools
-import requests
-
 from ..constants import API_URLS
+from ..utils import fetch
 
 
 class ClassicLeague():
     """A class representing a classic league in the Fantasy Premier League."""
-    def __init__(self, league_information):
-        self._league = league_information["league"]
-        self.id = self._league["id"]
+    def __init__(self, league_information, session):
+        self._session = session
 
-        #: A dictionary containing information about new entries to the league.
-        self.new_entries = league_information["new_entries"]
-        #: The name of the league.
-        self.name = self._league["name"]
-        #: The shortname of the league.
-        self.short_name = self._league["short_name"]
-        #: The date the league was created.
-        self.created = self._league["created"]
-        #: Whether the league is closed or not.
-        self.closed = self._league["closed"]
-        #: Whether the league's forum is disabled.
-        self.forum_disabled = self._league["forum_disabled"]
-        #: Whether the league is public.
-        self.is_public = self._league["make_code_public"]
-        #: The league's rank.
-        self.rank = self._league["rank"]
-        #: The league's size.
-        self.size = self._league["size"]
-        #: The league's type.
-        self.league_type = self._league["league_type"]
-        #: The scoring system the league uses.
-        self.scoring_system = self._league["_scoring"]
-        #: Whether the standings are being reprocessed.
-        self.reprocessing_standings = self._league["reprocess_standings"]
-        #: Admin entry.
-        self.admin_entry = self._league["admin_entry"]
-        #: The gameweek the league started in.
-        self.started = self._league["start_event"]
-        #: The standings of the league.
-        self.standings = None
+        for k, v in league_information.items():
+            setattr(self, k, v)
 
-    def get_standings(self):
-        """Returns league standings for all teams in the league."""
-        standings = []
-
-        for page in itertools.count(start=1):
-            url = "{}?ls-page={}".format(
-                API_URLS["league_classic"].format(self.league_id), page)
-            page_results = requests.get(url).json()["standings"]["results"]
-
-            if page_results:
-                standings.extend(page_results)
-            else:
-                self.standings = standings
-                break
+    async def get_standings(self, page):
+        """Returns the league's standings of the given page."""
+        url = "{}?ls-page={}".format(
+                API_URLS["league_classic"].format(self.league["id"]), page)
+        standings = await fetch(self._session, url)
+        return standings["standings"]
 
     def __str__(self):
-        return "{} - {}".format(self.name, self.league_id)
+        return f"{self.league['name']} - {self.league['id']}"

--- a/fpl/models/fixture.py
+++ b/fpl/models/fixture.py
@@ -11,147 +11,86 @@ def add_player(location, information):
 
 class Fixture():
     """A class representing fixtures in the Fantasy Premier League."""
-    def __init__(self, fixture):
-        self.fixture_id = fixture["id"]
-        self.kickoff_time_formatted = fixture["kickoff_time_formatted"]
-        self.started = fixture["started"]
-        self.event_day = fixture["event_day"]
-        self.deadline_time = fixture["deadline_time"]
-        self.deadline_time_formatted = fixture["deadline_time_formatted"]
-        self.statistics = fixture["stats"]
-        self.team_h_difficulty = fixture["team_h_difficulty"]
-        self.team_a_difficulty = fixture["team_a_difficulty"]
-        self.code = fixture["code"]
-        self.kickoff_time = fixture["kickoff_time"]
-        self.team_h_score = fixture["team_h_score"]
-        self.team_a_score = fixture["team_a_score"]
-        self.finished = fixture["finished"]
-        self.minutes = fixture["minutes"]
-        self.provisional_start_time = fixture["provisional_start_time"]
-        self.finished_provisional = fixture["finished_provisional"]
-        self.gameweek = fixture["event"]
-        self.team_a = team_converter(fixture["team_a"])
-        self.team_h = team_converter(fixture["team_h"])
-
-        self.goalscorers = None
-        self.assisters = None
-        self.own_goalscorers = None
-        self.yellow_cards = None
-        self.red_cards = None
-        self.penalty_saves = None
-        self.penalty_misses = None
-        self.saves = None
-        self.bonus = None
-        self.bps = None
+    def __init__(self, fixture_information):
+        for k, v in fixture_information.items():
+            setattr(self, k, v)
 
     def _get_players(self, metric):
         """Helper function that returns a dictionary containing players for the
         given metric (away and home).
         """
-        away = []
-        home = []
-
-        # Get the statistics for the given metric
-        for statistic in self.statistics:
+        for statistic in self.stats:
             if metric in statistic.keys():
                 player_information = statistic[metric]
 
-        # Create Player objects
-        for location in ["a", "h"]:
-            for information in player_information[location]:
-                if location == "a":
-                    add_player(away, information)
-                else:
-                    add_player(home, information)
-
-        return away, home
+        return player_information
 
     def get_goalscorers(self):
         """Returns all players who scored in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("goals_scored")
-
-        self.goalscorers = {"away": away, "home": home}
+        return self._get_players("goals_scored")
 
     def get_assisters(self):
         """Returns all players who made an assist in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("assists")
-
-        self.assisters = {"away": away, "home": home}
+        return self._get_players("assists")
 
     def get_own_goalscorers(self):
         """Returns all players who scored an own goal in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("own_goals")
-
-        self.own_goalscorers = {"away": away, "home": home}
+        return self._get_players("own_goals")
 
     def get_yellow_cards(self):
         """Returns all players who received a yellow card in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("yellow_cards")
-
-        self.yellow_cards = {"away": away, "home": home}
+        return self._get_players("yellow_cards")
 
     def get_red_cards(self):
         """Returns all players who received a red card in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("red_cards")
-
-        self.red_cards = {"away": away, "home": home}
+        return self._get_players("red_cards")
 
     def get_penalty_saves(self):
         """Returns all players who saved a penalty in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("penalties_saved")
-
-        self.penalty_saves = {"away": away, "home": home}
+        return self._get_players("penalties_saved")
 
     def get_penalty_misses(self):
         """Returns all players who missed a penalty in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("penalties_missed")
-
-        self.penalty_misses = {"away": away, "home": home}
+        return self._get_players("penalties_missed")
 
     def get_saves(self):
         """Returns all players who made a save in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("saves")
-
-        self.saves = {"away": away, "home": home}
+        return self._get_players("saves")
 
     def get_bonus(self):
         """Returns all players who received bonus points in the fixture."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("bonus")
-
-        self.bonus = {"away": away, "home": home}
+        return self._get_players("bonus")
 
     def get_bps(self):
         """Returns the bonus points of each player."""
-        if not self.statistics:
+        if not self.finished:
             return
 
-        away, home = self._get_players("bps")
-
-        self.bps = {"away": away, "home": home}
+        return self._get_players("bps")

--- a/fpl/models/gameweek.py
+++ b/fpl/models/gameweek.py
@@ -6,59 +6,33 @@ from .player import Player
 
 class Gameweek():
     """A class representing a gameweek of the Fantasy Premier League."""
-    def __init__(self, gameweek_id):
-        self.gameweek_id = int(gameweek_id)
-
-        self._additional = self._get_additional()
-        self._specific = self._get_specific()
-
+    def __init__(self, gameweek_information):
+        self.id = gameweek_information["id"]
         #: A `datetime` object of the gameweek's deadline.
-        self.deadline = self._specific["deadline_time"]
+        self.deadline = gameweek_information["deadline_time"]
         #: A boolean that signifies if the gameweek is already finished.
-        self.finished = self._specific["finished"]
+        self.finished = gameweek_information["finished"]
         #: The name of the gameweek, e.g. "Gameweek 1".
-        self.name = self._specific["name"]
+        self.name = gameweek_information["name"]
 
         #: A boolean that signifies if the gameweek is the current gameweek.
-        self.is_current = self._specific["is_current"]
+        self.is_current = gameweek_information["is_current"]
         #: A boolean that signifies if the gameweek is the next gameweek.
-        self.is_next = self._specific["is_next"]
+        self.is_next = gameweek_information["is_next"]
         #: A boolean that signifies if the gameweek is the previous gameweek.
-        self.is_previous = self._specific["is_previous"]
+        self.is_previous = gameweek_information["is_previous"]
 
         #: The average score of the gameweek.
-        self.average_score = self._specific["average_entry_score"]
+        self.average_score = gameweek_information["average_entry_score"]
         #: The `user_id` of the best player of the gameweek.
-        self.best_player = self._specific["highest_scoring_entry"]
+        self.best_player = gameweek_information["highest_scoring_entry"]
         #: The highest score of the gameweek.
-        self.highest_score = self._specific["highest_score"]
+        self.highest_score = gameweek_information["highest_score"]
+
+        #: The fixtures of the gameweek.
+        self.fixtures = gameweek_information["fixtures"]
         #: The players that played in the gameweek.
-        self.players = None
-
-    @property
-    def fixtures(self):
-        """A list of dictionaries containing information about the fixtures of
-        the gameweek.
-        """
-        return self._additional["fixtures"]
-
-    def get_players(self):
-        """Returns a list of players that played in the gameweek."""
-        player_ids = [int(player_id) for player_id
-                      in self._additional["elements"].keys()]
-        response = requests.get(API_URLS["players"]).json()
-        players = [Player(player["id"], player) for player in response
-                   if player["id"] in player_ids]
-
-        self.players = players
-
-    def _get_specific(self):
-        response = requests.get(API_URLS["gameweeks"]).json()
-        return response[self.gameweek_id - 1]
-
-    def _get_additional(self):
-        return requests.get(API_URLS["gameweek_live"].format(
-            self.gameweek_id)).json()
+        self.players = gameweek_information["elements"]
 
     def __str__(self):
         return "{} - {}".format(self.name, self.deadline)

--- a/fpl/models/gameweek.py
+++ b/fpl/models/gameweek.py
@@ -1,7 +1,4 @@
-import requests
-
 from ..constants import API_URLS
-from .player import Player
 
 
 class Gameweek():

--- a/fpl/models/gameweek.py
+++ b/fpl/models/gameweek.py
@@ -7,32 +7,8 @@ from .player import Player
 class Gameweek():
     """A class representing a gameweek of the Fantasy Premier League."""
     def __init__(self, gameweek_information):
-        self.id = gameweek_information["id"]
-        #: A `datetime` object of the gameweek's deadline.
-        self.deadline = gameweek_information["deadline_time"]
-        #: A boolean that signifies if the gameweek is already finished.
-        self.finished = gameweek_information["finished"]
-        #: The name of the gameweek, e.g. "Gameweek 1".
-        self.name = gameweek_information["name"]
-
-        #: A boolean that signifies if the gameweek is the current gameweek.
-        self.is_current = gameweek_information["is_current"]
-        #: A boolean that signifies if the gameweek is the next gameweek.
-        self.is_next = gameweek_information["is_next"]
-        #: A boolean that signifies if the gameweek is the previous gameweek.
-        self.is_previous = gameweek_information["is_previous"]
-
-        #: The average score of the gameweek.
-        self.average_score = gameweek_information["average_entry_score"]
-        #: The `user_id` of the best player of the gameweek.
-        self.best_player = gameweek_information["highest_scoring_entry"]
-        #: The highest score of the gameweek.
-        self.highest_score = gameweek_information["highest_score"]
-
-        #: The fixtures of the gameweek.
-        self.fixtures = gameweek_information["fixtures"]
-        #: The players that played in the gameweek.
-        self.players = gameweek_information["elements"]
+        for k, v in gameweek_information.items():
+            setattr(self, k, v)
 
     def __str__(self):
-        return "{} - {}".format(self.name, self.deadline)
+        return "{} - {}".format(self.name, self.deadline_time_formatted)

--- a/fpl/models/h2h_league.py
+++ b/fpl/models/h2h_league.py
@@ -8,15 +8,14 @@ class H2HLeague():
     """
     A class representing a h2h league in the Fantasy Premier League.
     """
-    def __init__(self, league_id, session=None):
-        self.league_id = league_id
-        self._information = self._get_information()
-        self._league = self._information["league"]
+    def __init__(self, league_information, session=None):
+        self._league = league_information["league"]
+        self.id = self._league["id"]
         #: Session for H2H fixtures
         self._session = session
 
         #: A dictionary containing information about new entries to the league.
-        self.new_entries = self._information["new_entries"]
+        self.new_entries = league_information["new_entries"]
 
         #: The name of the league.
         self.name = self._league["name"]
@@ -50,11 +49,6 @@ class H2HLeague():
         self.started = self._league["start_event"]
         #: The fixtures of the league.
         self.fixtures = None
-
-    def _get_information(self):
-        """Returns information about the given league."""
-        return requests.get(API_URLS["league_h2h"].format(
-            self.league_id)).json()
 
     def __str__(self):
         return "{} - {}".format(self.name, self.league_id)

--- a/fpl/models/h2h_league.py
+++ b/fpl/models/h2h_league.py
@@ -1,5 +1,4 @@
 import asyncio
-import itertools
 
 from ..constants import API_URLS
 from ..utils import fetch, get_current_gameweek

--- a/fpl/models/h2h_league.py
+++ b/fpl/models/h2h_league.py
@@ -1,7 +1,8 @@
+import asyncio
 import itertools
-import requests
 
 from ..constants import API_URLS
+from ..utils import fetch, get_current_gameweek
 
 
 class H2HLeague():
@@ -9,62 +10,30 @@ class H2HLeague():
     A class representing a h2h league in the Fantasy Premier League.
     """
     def __init__(self, league_information, session=None):
-        self._league = league_information["league"]
-        self.id = self._league["id"]
-        #: Session for H2H fixtures
         self._session = session
 
-        #: A dictionary containing information about new entries to the league.
-        self.new_entries = league_information["new_entries"]
-
-        #: The name of the league.
-        self.name = self._league["name"]
-        #: Whether the league has started or not.
-        self.has_started = self._league["has_started"]
-        #: Whether or not the league can be deleted.
-        self.can_delete = self._league["can_delete"]
-        #: The shortname of the league.
-        self.short_name = self._league["short_name"]
-        #: The date the league was created.
-        self.created = self._league["created"]
-        #: Whether the league is closed or not.
-        self.closed = self._league["closed"]
-        #: Whether the league's forum is disabled.
-        self.forum_disabled = self._league["forum_disabled"]
-        #: Whether the league is public.
-        self.is_public = self._league["make_code_public"]
-        #: The league's rank.
-        self.rank = self._league["rank"]
-        #: The league's size.
-        self.size = self._league["size"]
-        #: The league's type.
-        self.league_type = self._league["league_type"]
-        #: The scoring system the league uses.
-        self.scoring_system = self._league["_scoring"]
-        #: Information about the knockout rounds.
-        self.ko_rounds = self._league["ko_rounds"]
-        #: Admin entry.
-        self.admin_entry = self._league["admin_entry"]
-        #: The gameweek the league started in.
-        self.started = self._league["start_event"]
-        #: The fixtures of the league.
-        self.fixtures = None
+        for k, v in league_information.items():
+            setattr(self, k, v)
 
     def __str__(self):
-        return "{} - {}".format(self.name, self.league_id)
+        return f"{self.league['name']} - {self.league['id']}"
 
-    def get_fixtures(self):
+    async def get_fixtures(self, gameweek=None):
         """Returns h2h results/fixtures for given league, login required."""
         if not self._session:
             return
 
-        fixtures = []
-        for page in itertools.count(start=1):
-            url = API_URLS["h2h"].format(self.league_id, page)
-            page_results = self._session.get(url).json()["matches"]["results"]
+        if gameweek:
+            gameweeks = range(gameweek, gameweek + 1)
+        else:
+            current_gameweek = await get_current_gameweek(self._session)
+            gameweeks = range(1, current_gameweek + 1)
 
-            if page_results:
-                fixtures.extend(page_results)
-            else:
-                self.fixtures = fixtures
-                break
+        tasks = [asyncio.ensure_future(
+                 fetch(self._session,
+                       API_URLS["h2h"].format(self.league["id"], page)))
+                 for page in gameweeks]
+
+        fixtures = await asyncio.gather(*tasks)
+
+        return fixtures

--- a/fpl/models/player.py
+++ b/fpl/models/player.py
@@ -38,11 +38,11 @@ class Player():
         #: The amount of penalties the player has missed.
         self.penalties_missed = player["penalties_missed"]
         #: The type of player the player is (1, 2, 3 or 4).
-        player_type = player["element_type"]
+        self.player_type = player["element_type"]
         #: The amount of points a player has scored this season.
         self.points = player["total_points"]
         #: The position that the player plays in.
-        self.position = position_converter(player_type)
+        self.position = position_converter(self.player_type)
         #: The amount of points the player scores per game on average.
         self.ppg = player["points_per_game"]
         #: The player's current price.

--- a/fpl/models/player.py
+++ b/fpl/models/player.py
@@ -1,80 +1,13 @@
-import requests
-
 from ..constants import API_URLS
 from ..utils import team_converter, position_converter
 
 
 class Player():
     """A class representing a player in the Fantasy Premier League."""
-    def __init__(self, player):
-        self.id = player["id"]
+    def __init__(self, player_information):
+        for k, v in player_information.items():
+            setattr(self, k, v)
 
-        #: The amount of goals assisted by the player.
-        self.assists = player["assists"]
-        #: The amount of bonus points the player has scored.
-        self.bps = player["bps"]
-        #: The amount of clean sheets the player has had.
-        self.clean_sheets = player["clean_sheets"]
-        #: The player's first name.
-        self.first_name = player["first_name"]
-        #: The player's form.
-        self.form = player["form"]
-        #: The player's points in the current gameweek.
-        self.gameweek_points = player["event_points"]
-        #: The player's price change in the current gameweek.
-        self.gameweek_price_change = player["cost_change_event"]
-        #: The player's transfers in in the current gameweek.
-        self.gameweek_transfers_in = player["transfers_in_event"]
-        #: The player's transfers out in the current gameweek.
-        self.gameweek_transfers_out = player["transfers_out_event"]
-        #: The amount of goals scored by the player.
-        self.goals = player["goals_scored"]
-        #: The amount of minutes the player has played.
-        self.minutes = player["minutes"]
-        #: The player's web name.
-        self.name = player["web_name"]
-        #: News about the player.
-        self.news = player["news"]
-        #: The amount of penalties the player has missed.
-        self.penalties_missed = player["penalties_missed"]
-        #: The type of player the player is (1, 2, 3 or 4).
-        self.player_type = player["element_type"]
-        #: The amount of points a player has scored this season.
-        self.points = player["total_points"]
-        #: The position that the player plays in.
-        self.position = position_converter(self.player_type)
-        #: The amount of points the player scores per game on average.
-        self.ppg = player["points_per_game"]
-        #: The player's current price.
-        self.price = player["now_cost"] / 10.0
-        #: The amount of red cards the player has received.
-        self.red_cards = player["red_cards"]
-        #: The amount of saves the player has made.
-        self.saves = player["saves"]
-        #: The player's second name.
-        self.second_name = player["second_name"]
-        #: The percentage of users the player is selected by.
-        self.selected_by = float(player["selected_by_percent"])
-        #: The status of the player, which can be available, injured or ...
-        self.status = player["status"]
-        #: The player's squad number.
-        self.squad_number = player["squad_number"]
-        #: The ID of the team the player plays for.
-        self.team_id = player["team"]
-        #: The team the player currently plays for.
-        self.team = team_converter(self.team_id)
-        #: The player's transfers in in the current season.
-        self.transfers_in = player["transfers_in"]
-        #: The player's transfers out in the current season.
-        self.transfers_out = player["transfers_out"]
-        #: The amount of yellow cards the player has received.
-        self.yellow_cards = player["yellow_cards"]
-        #: The player's expected points in this gameweek.
-        self.ep_this = player["ep_this"]
-        #: The player's expected points in the next gameweek.
-        self.ep_next = player["ep_next"]
-
-    @property
     def games_played(self):
         """Returns the amount of games a player has played in."""
         return sum([1 for fixture in self.fixtures if fixture["minutes"] > 0])
@@ -95,15 +28,5 @@ class PlayerSummary:
     """A class representing a player in the Fantasy Premier League's summary.
     """
     def __init__(self, player_summary):
-        #: Information about the player's upcoming fixture.
-        self.explain = player_summary["explain"]
-        #: List of the player's upcoming fixtures.
-        self.fixtures = player_summary["fixtures"]
-        #: List of the player's closest three upcoming fixtures.
-        self.fixtures_summary = player_summary["fixtures_summary"]
-        #: List of the player's performance in fixtures of the current season.
-        self.history = player_summary["history"]
-        #: List of a summary of the player's performance in previous seasons.
-        self.history_past = player_summary["history_past"]
-        #: List of the player's performance in his three most recent games.
-        self.history_summary = player_summary["history_summary"]
+        for k, v in player_summary.items():
+            setattr(self, k, v)

--- a/fpl/models/player.py
+++ b/fpl/models/player.py
@@ -8,6 +8,7 @@ class Player():
         for k, v in player_information.items():
             setattr(self, k, v)
 
+    @property
     def games_played(self):
         """Returns the amount of games a player has played in."""
         return sum([1 for fixture in self.fixtures if fixture["minutes"] > 0])
@@ -18,7 +19,7 @@ class Player():
         """
         if self.minutes == 0:
             return 0
-        return self.points / float(self.minutes)
+        return self.total_points / float(self.minutes)
 
     def __str__(self):
         return "{} - {} - {}".format(self.name, self.position, self.team)

--- a/fpl/models/player.py
+++ b/fpl/models/player.py
@@ -4,105 +4,75 @@ from ..constants import API_URLS
 from ..utils import team_converter, position_converter
 
 
-def get_additional(player_id):
-    """Returns additional information about the player with the given
-    player ID.
-
-    :param int player_id: A player's ID
-    """
-    players = requests.get(API_URLS["players"]).json()
-    for player in players:
-        if player["id"] == player_id:
-            return player
-    return []
-
-
 class Player():
     """A class representing a player in the Fantasy Premier League."""
-    def __init__(self, player_id, additional=None):
-        self.player_id = player_id
-        self._specific = self._get_specific()
-        self._additional = additional or get_additional(player_id)
+    def __init__(self, player):
+        self.id = player["id"]
 
         #: The amount of goals assisted by the player.
-        self.assists = self._additional["assists"]
+        self.assists = player["assists"]
         #: The amount of bonus points the player has scored.
-        self.bps = self._additional["bps"]
+        self.bps = player["bps"]
         #: The amount of clean sheets the player has had.
-        self.clean_sheets = self._additional["clean_sheets"]
-        #: Information about the player's upcoming fixture.
-        self.explain = self._specific["explain"]
+        self.clean_sheets = player["clean_sheets"]
         #: The player's first name.
-        self.first_name = self._additional["first_name"]
-        #: List of the player's upcoming fixtures.
-        self.fixtures = self._specific["fixtures"]
-        #: List of the player's closest three upcoming fixtures.
-        self.fixtures_summary = self._specific["fixtures_summary"]
+        self.first_name = player["first_name"]
         #: The player's form.
-        self.form = self._additional["form"]
+        self.form = player["form"]
         #: The player's points in the current gameweek.
-        self.gameweek_points = self._additional["event_points"]
+        self.gameweek_points = player["event_points"]
         #: The player's price change in the current gameweek.
-        self.gameweek_price_change = self._additional["cost_change_event"]
+        self.gameweek_price_change = player["cost_change_event"]
         #: The player's transfers in in the current gameweek.
-        self.gameweek_transfers_in = self._additional["transfers_in_event"]
+        self.gameweek_transfers_in = player["transfers_in_event"]
         #: The player's transfers out in the current gameweek.
-        self.gameweek_transfers_out = self._additional["transfers_out_event"]
+        self.gameweek_transfers_out = player["transfers_out_event"]
         #: The amount of goals scored by the player.
-        self.goals = self._additional["goals_scored"]
-        #: List of the player's performance in fixtures of the current season.
-        self.history = self._specific["history"]
-        #: List of a summary of the player's performance in previous seasons.
-        self.history_past = self._specific["history_past"]
-        #: List of the player's performance in his three most recent games.
-        self.history_summary = self._specific["history_summary"]
+        self.goals = player["goals_scored"]
         #: The amount of minutes the player has played.
-        self.minutes = self._additional["minutes"]
+        self.minutes = player["minutes"]
         #: The player's web name.
-        self.name = self._additional["web_name"]
+        self.name = player["web_name"]
         #: News about the player.
-        self.news = self._additional["news"]
+        self.news = player["news"]
         #: The amount of penalties the player has missed.
-        self.penalties_missed = self._additional["penalties_missed"]
+        self.penalties_missed = player["penalties_missed"]
         #: The type of player the player is (1, 2, 3 or 4).
-        self.player_type = self._additional["element_type"]
+        player_type = player["element_type"]
         #: The amount of points a player has scored this season.
-        self.points = self._additional["total_points"]
+        self.points = player["total_points"]
         #: The position that the player plays in.
-        self.position = position_converter(self.player_type)
+        self.position = position_converter(player_type)
         #: The amount of points the player scores per game on average.
-        self.ppg = self._additional["points_per_game"]
+        self.ppg = player["points_per_game"]
         #: The player's current price.
-        self.price = self._additional["now_cost"] / 10.0
+        self.price = player["now_cost"] / 10.0
         #: The amount of red cards the player has received.
-        self.red_cards = self._additional["red_cards"]
+        self.red_cards = player["red_cards"]
         #: The amount of saves the player has made.
-        self.saves = self._additional["saves"]
+        self.saves = player["saves"]
         #: The player's second name.
-        self.second_name = self._additional["second_name"]
+        self.second_name = player["second_name"]
         #: The percentage of users the player is selected by.
-        self.selected_by = float(self._additional["selected_by_percent"])
+        self.selected_by = float(player["selected_by_percent"])
         #: The status of the player, which can be available, injured or ...
-        self.status = self._additional["status"]
+        self.status = player["status"]
         #: The player's squad number.
-        self.squad_number = self._additional["squad_number"]
+        self.squad_number = player["squad_number"]
         #: The ID of the team the player plays for.
-        self.team_id = self._additional["team"]
+        self.team_id = player["team"]
         #: The team the player currently plays for.
         self.team = team_converter(self.team_id)
         #: The player's transfers in in the current season.
-        self.transfers_in = self._additional["transfers_in"]
+        self.transfers_in = player["transfers_in"]
         #: The player's transfers out in the current season.
-        self.transfers_out = self._additional["transfers_out"]
+        self.transfers_out = player["transfers_out"]
         #: The amount of yellow cards the player has received.
-        self.yellow_cards = self._additional["yellow_cards"]
-
-        self.ep_this = self._additional["ep_this"]
-        self.ep_next = self._additional["ep_next"]
-
-    def _get_specific(self):
-        """Returns the player with the specific player_id."""
-        return requests.get(API_URLS["player"].format(self.player_id)).json()
+        self.yellow_cards = player["yellow_cards"]
+        #: The player's expected points in this gameweek.
+        self.ep_this = player["ep_this"]
+        #: The player's expected points in the next gameweek.
+        self.ep_next = player["ep_next"]
 
     @property
     def games_played(self):
@@ -119,3 +89,21 @@ class Player():
 
     def __str__(self):
         return "{} - {} - {}".format(self.name, self.position, self.team)
+
+
+class PlayerSummary:
+    """A class representing a player in the Fantasy Premier League's summary.
+    """
+    def __init__(self, player_summary):
+        #: Information about the player's upcoming fixture.
+        self.explain = player_summary["explain"]
+        #: List of the player's upcoming fixtures.
+        self.fixtures = player_summary["fixtures"]
+        #: List of the player's closest three upcoming fixtures.
+        self.fixtures_summary = player_summary["fixtures_summary"]
+        #: List of the player's performance in fixtures of the current season.
+        self.history = player_summary["history"]
+        #: List of a summary of the player's performance in previous seasons.
+        self.history_past = player_summary["history_past"]
+        #: List of the player's performance in his three most recent games.
+        self.history_summary = player_summary["history_summary"]

--- a/fpl/models/team.py
+++ b/fpl/models/team.py
@@ -23,7 +23,7 @@ class Team():
             players = await fetch(self.session, API_URLS["players"])
 
         team_players = [player for player in players
-                        if player["team_code"] == self.id]
+                        if player["team"] == self.id]
         self.players = team_players
 
         if return_json:
@@ -41,6 +41,8 @@ class Team():
 
         if not hasattr(self, "players"):
             await self.get_players()
+
+        print(self.players)
 
         player = self.players[0]
         url = API_URLS["player"].format(player["id"])

--- a/fpl/models/team.py
+++ b/fpl/models/team.py
@@ -9,6 +9,7 @@ class Team():
     def __init__(self, team_information):
         self._information = team_information
 
+        self.id = self._information["id"]
         #: The name of the team, e.g. "Arsenal".
         self.name = self._information["name"]
         #: The team's code.

--- a/fpl/models/team.py
+++ b/fpl/models/team.py
@@ -1,76 +1,60 @@
 import requests
 
 from ..constants import API_URLS
+from ..utils import fetch
 from .player import Player
+from .fixture import Fixture
 
 
 class Team():
     """A class representing a real team in the Fantasy Premier League."""
-    def __init__(self, team_information):
-        self._information = team_information
+    def __init__(self, team_information, session):
+        self.session = session
+        for k, v in team_information.items():
+            setattr(self, k, v)
 
-        self.id = self._information["id"]
-        #: The name of the team, e.g. "Arsenal".
-        self.name = self._information["name"]
-        #: The team's code.
-        self.code = self._information["code"]
-        #: The short name of the team, e.g. "ARS".
-        self.short_name = self._information["short_name"]
-        #: The team's unavailability.
-        self.unavailable = self._information["unavailable"]
-        #: Strength of the team.
-        self.strength = self._information["strength"]
-        #: The team's position in the table.
-        self.position = self._information["position"]
-        #: Amount of games played.
-        self.played = self._information["played"]
-        #: Amount of games won.
-        self.won = self._information["win"]
-        #: Amount of games lost.
-        self.lost = self._information["loss"]
-        #: Amount of games drawn.
-        self.drawn = self._information["draw"]
-        #: Amount of points.
-        self.points = self._information["points"]
-        #: The team's form.
-        self.form = self._information["form"]
-        #: Team's overall strength at home.
-        self.strength_overall_home = self._information["strength_overall_home"]
-        #: Team's overall strength away from home.
-        self.strength_overall_away = self._information["strength_overall_away"]
-        #: Team's attacking strength at home.
-        self.strength_attack_home = self._information["strength_attack_home"]
-        #: Team's attacking strength away from home.
-        self.strength_attack_away = self._information["strength_attack_away"]
-        #: Team's defensive strength at home.
-        self.strength_defence_home = self._information["strength_defence_home"]
-        #: Team's defensive strength away from home.
-        self.strength_defence_away = self._information["strength_defence_away"]
-        #: A dictionary with information about the team's current fixture.
-        self.current_fixture = self._information["current_event_fixture"][0]
-        #: A dictionary with information about the team's next fixture.
-        self.next_fixture = self._information["next_event_fixture"][0]
-        #: The team's players.
-        self.players = None
-
-    def get_players(self):
+    async def get_players(self, return_json=False):
         """Sets the `players` property as a list of players that play for the
         team.
-        """
-        response = requests.get(API_URLS["players"])
-        if response.status_code == 200:
-            players = [Player(player["id"], player)
-                       for player in response.json()
-                       if player["team_code"] == self.code]
-        self.players = players
 
-    def get_fixtures(self):
+        :param boolean return_json: Flag for returning JSON
+        """
+        if hasattr(self, "players"):
+            players = self.players
+        else:
+            players = await fetch(self.session, API_URLS["players"])
+
+        team_players = [player for player in players
+                        if player["team_code"] == self.id]
+        self.players = team_players
+
+        if return_json:
+            return team_players
+        return [Player(player) for player in team_players]
+
+    async def get_fixtures(self, return_json=False):
         """Sets the team's fixtures equal to that of one of its player's
-        fixtures."""
-        if not self.players:
-            self.get_players()
+        fixtures.
+
+        :param boolean return_json: Flag for returning JSON
+        """
+        if hasattr(self, "fixtures"):
+            return self.fixtures
+
+        if not hasattr(self, "players"):
+            await self.get_players()
+
         player = self.players[0]
-        self.fixtures = player.fixtures
+        url = API_URLS["player"].format(player["id"])
+        player_summary = await fetch(self.session, url)
+
+        self.fixtures = player_summary["fixtures"]
+
+        if return_json:
+            return self.fixtures
+
+        # TODO: create TeamFixture
+        return self.fixtures
 
     def __str__(self):
         return self.name

--- a/fpl/models/team.py
+++ b/fpl/models/team.py
@@ -6,9 +6,8 @@ from .player import Player
 
 class Team():
     """A class representing a real team in the Fantasy Premier League."""
-    def __init__(self, team_id):
-        self.team_id = team_id
-        self._information = self._get_information()
+    def __init__(self, team_information):
+        self._information = team_information
 
         #: The name of the team, e.g. "Arsenal".
         self.name = self._information["name"]
@@ -71,10 +70,6 @@ class Team():
             self.get_players()
         player = self.players[0]
         self.fixtures = player.fixtures
-
-    def _get_information(self):
-        response = requests.get(API_URLS["teams"]).json()
-        return response[self.team_id - 1]
 
     def __str__(self):
         return self.name

--- a/fpl/models/team.py
+++ b/fpl/models/team.py
@@ -1,9 +1,7 @@
-import requests
-
 from ..constants import API_URLS
 from ..utils import fetch
-from .player import Player
 from .fixture import Fixture
+from .player import Player
 
 
 class Team():

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -17,7 +17,7 @@ class User():
         self._session = session
         self._information = user_information
         self._entry = self._information["entry"]
-
+        self.id = self._entry["id"]
         #: The user's first name.
         self.first_name = self._entry["player_first_name"]
         #: The user's second name.
@@ -75,7 +75,7 @@ class User():
     def history(self):
         """Returns a dictionary containing the history of the user."""
         return requests.get(API_URLS["user_history"].format(
-            self.user_id)).json()
+            self.id)).json()
 
     @property
     def season_history(self):
@@ -121,7 +121,7 @@ class User():
         picks = {}
         for gameweek in range(1, 39):
             team = requests.get(API_URLS["user_picks"].format(
-                self.user_id, gameweek))
+                self.id, gameweek))
 
             if team.status_code == 404:
                 return picks
@@ -136,7 +136,7 @@ class User():
             raise "User must be logged in."
 
         response = self._session.get(API_URLS["user_team"].format(
-            self.user_id)).json()
+            self.id)).json()
 
         if response == {"details": "You cannot view this entry"}:
             raise ValueError("User ID does not match provided email address!")
@@ -231,7 +231,7 @@ class User():
         the user has made so far.
         """
         return requests.get(API_URLS["user_transfers"].format(
-            self.user_id)).json()
+            self.id)).json()
 
     @property
     def wildcards(self):

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -195,5 +195,5 @@ class User():
         return await fetch(self._session, API_URLS["watchlist"])
 
     def __str__(self):
-        return "{} {} - {}".format(
-            self.first_name, self.second_name, self.region_name)
+        return (f"{self.player_first_name} {self.player_last_name} - "
+                f"{self.player_region_name}")

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -20,7 +20,10 @@ class User():
         self.leagues = user_information["leagues"]
 
     async def get_gameweek_history(self, gameweek=None):
-        """Returns a list containing the gameweek history of the user."""
+        """Returns a list containing the gameweek history of the user.
+
+        :gameweek (`int`, optional): The gameweek. Defaults to None.
+        """
         if hasattr(self, "_history"):
             history = self._history
         else:
@@ -48,7 +51,10 @@ class User():
         return history["season"]
 
     async def get_chips_history(self, gameweek=None):
-        """Returns a list containing the chip history of the user."""
+        """Returns a list containing the chip history of the user.
+
+        :gameweek (`int`, optional): The gameweek. Defaults to None.
+        """
         if hasattr(self, "_history"):
             history = self._history
         else:
@@ -65,7 +71,10 @@ class User():
         return history["chips"]
 
     async def get_picks(self, gameweek=None):
-        """Returns a list containing the user's picks each gameweek."""
+        """Returns a list containing the user's picks each gameweek.
+
+        :gameweek (`int`, optional): The gameweek. Defaults to None.
+        """
         if hasattr(self, "_picks"):
             picks = self._picks
         else:
@@ -84,7 +93,10 @@ class User():
         return [pick["picks"] for pick in picks]
 
     async def get_active_chips(self, gameweek=None):
-        """Returns a list containing the user's active chips each gameweek."""
+        """Returns a list containing the user's active chips each gameweek.
+
+        :gameweek (`int`, optional): The gameweek. Defaults to None.
+        """
         if hasattr(self, "_picks"):
             picks = self._picks
         else:
@@ -104,7 +116,10 @@ class User():
 
     async def get_automatic_substitutions(self, gameweek=None):
         """Returns a list containing the user's automatic substitutions each
-        gameweek."""
+        gameweek.
+
+        :gameweek (`int`, optional): The gameweek. Defaults to None.
+        """
         if hasattr(self, "_picks"):
             picks = self._picks
         else:
@@ -123,7 +138,10 @@ class User():
         return [pick["automatic_subs"] for pick in picks]
 
     async def get_team(self):
-        """Returns a logged in user's current team."""
+        """Returns a logged in user's current team.
+
+        :gameweek (`int`, optional): The gameweek. Defaults to None.
+        """
         if not self._session:
             raise "User must be logged in."
 
@@ -138,6 +156,8 @@ class User():
     async def get_transfers(self, gameweek=None):
         """Returns a list containing information about all the transfers the
         user has made so far.
+
+        :gameweek (`int`, optional): The gameweek. Defaults to None.
         """
         if hasattr(self, "_transfers"):
             return self._transfers["history"]

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from ..constants import API_URLS
-from ..utils import fetch, team_converter
+from ..utils import fetch
 
 
 def valid_gameweek(gameweek):
@@ -15,133 +15,114 @@ class User():
     """A class representing a user of the Fantasy Premier League."""
     def __init__(self, user_information, session):
         self._session = session
-        self._information = user_information
-        self._entry = self._information["entry"]
-        self.id = self._entry["id"]
-        #: The user's first name.
-        self.first_name = self._entry["player_first_name"]
-        #: The user's second name.
-        self.second_name = self._entry["player_last_name"]
-        #: The user's team's name.
-        self.team_name = self._entry["name"]
-        #: The user's email address.
-        self.email = self._entry["email"]
-        #: The user's favourite team.
-        self.favourite_team = team_converter(self._entry["favourite_team"])
+        for k, v in user_information["entry"].items():
+            setattr(self, k, v)
+        self.leagues = user_information["leagues"]
 
-        #: The user's region's ID.
-        self.region_id = self._entry["player_region_id"]
-        #: The user's region's name.
-        self.region_name = self._entry["player_region_name"]
-        #: The user's region's short ISO.
-        self.region_short = self._entry["player_region_short_iso"]
+    async def get_gameweek_history(self, gameweek=None):
+        """Returns a list containing the gameweek history of the user."""
+        if hasattr(self, "_history"):
+            history = self._history
+        else:
+            history = await fetch(
+                self._session, API_URLS["user_history"].format(self.id))
 
-        #: The user's overall points.
-        self.overall_points = self._entry["summary_overall_points"]
-        #: The user's overall rank.
-        self.overall_rank = self._entry["summary_overall_rank"]
+        self._history = history
 
-        #: The user's points in the current gameweek.
-        self.gameweek_points = self._entry["summary_event_points"]
-        #: The user's rank in the current gameweek.
-        self.gameweek_rank = self._entry["summary_event_rank"]
-        #: The amount of transfers made by the user in the current gameweek.
-        self.gameweek_transfers = self._entry["event_transfers"]
-        #: The gameweek the user started playing.
-        self.gameweek_started = self._entry["started_event"]
-        #: The point hit the user took in the current gameweek.
-        self.gameweek_hit = self._entry["event_transfers_cost"]
-        #: Information about the user's current gameweek performance.
-        self.current_gameweek = self._entry["current_event"]
+        if gameweek:
+            valid_gameweek(gameweek)
+            return next(gw for gw in history["history"]
+                        if gw["event"] == gameweek)
 
-        #: The user's total transfers.
-        self.total_transfers = self._entry["total_transfers"]
-        #: The amount of money the user has in the bank.
-        self.bank = self._entry["bank"] / 10.0
-        #: The user's team's value.
-        self.team_value = self._entry["value"] / 10.0
-        #: The amount of free transfers the user currently has.
-        self.free_transfers = self._entry["extra_free_transfers"]
-
-        #: The user's cup status.
-        self.cup_status = self._information["cup_status"]
-        #: The user's cup matches.
-        self.cup_matches = self._information["cup_matches"]
-
-        #: Account deletion status.
-        self.deleted = self._entry["deleted"]
-
-    async def get_history(self):
-        """Returns a dictionary containing the history of the user."""
-        return await fetch(self._session, API_URLS["user_history"].format(
-            self.id))
+        return history["history"]
 
     async def get_season_history(self):
-        """Returns a list containing information about each of the seasons the
-        user has participated in.
-        """
-        try:
-            history = self.history
-        except:
-            history = await self.get_history()
+        """Returns a list containing the seasonal history of the user."""
+        if hasattr(self, "_history"):
+            history = self._history["season"]
+        else:
+            history = await fetch(
+                self._session, API_URLS["user_history"].format(self.id))
+
+        self._history = history
         return history["season"]
 
-    async def get_chips_history(self):
-        """Returns a list containing information about the usage of the
-        player's chips.
-        """
-        try:
-            history = self.history
-        except:
-            history = await self.get_history()
+    async def get_chips_history(self, gameweek=None):
+        """Returns a list containing the chip history of the user."""
+        if hasattr(self, "_history"):
+            history = self._history
+        else:
+            history = await fetch(
+                self._session, API_URLS["user_history"].format(self.id))
+
+        self._history = history
+
+        if gameweek:
+            valid_gameweek(gameweek)
+            return next(chip for chip in history["chips"]
+                        if chip["event"] == gameweek)
+
         return history["chips"]
 
-    async def get_leagues(self):
-        """Returns a dictionary containing information about all the leagues
-        that the user is participating in.
-        """
-        try:
-            history = self.history
-        except:
-            history = await self.get_history()
-        return history["leagues"]
+    async def get_picks(self, gameweek=None):
+        """Returns a list containing the user's picks each gameweek."""
+        if hasattr(self, "_picks"):
+            picks = self._picks
+        else:
+            tasks = [asyncio.ensure_future(
+                     fetch(self._session,
+                           API_URLS["user_picks"].format(self.id, gameweek)))
+                     for gameweek in range(1, self.current_event + 1)]
+            picks = await asyncio.gather(*tasks)
+            self._picks = picks
 
-    async def get_classic_leagues(self):
-        """Returns a list containing information about all the classic leagues
-        that the user is currently participating in.
-        """
-        try:
-            leagues = self.leagues
-        except:
-            leagues = await self.get_leagues()
-        return leagues["classic"]
+        if gameweek:
+            valid_gameweek(gameweek)
+            return next(pick["picks"] for pick in picks
+                        if pick["event"]["id"] == gameweek)
 
-    async def get_h2h_leagues(self):
-        """Returns a list containing information about all the h2h leagues that
-        the user is currently participating in.
-        """
-        try:
-            leagues = self.leagues
-        except:
-            leagues = await self.get_leagues()
-        return leagues["h2h"]
+        return [pick["picks"] for pick in picks]
 
-    async def get_picks(self):
-        """Returns a dictionary containing information about the user's chip
-        usage, automatic substitutions and picks, alongside general
-        information about each gameweek.
-        """
-        until = self.current_gameweek + 1
-        tasks = [asyncio.ensure_future(
-                 fetch(self._session,
-                       API_URLS["user_picks"].format(self.id, gw)))
-                 for gw in range(1, until)]
+    async def get_active_chips(self, gameweek=None):
+        """Returns a list containing the user's active chips each gameweek."""
+        if hasattr(self, "_picks"):
+            picks = self._picks
+        else:
+            tasks = [asyncio.ensure_future(
+                     fetch(self._session,
+                           API_URLS["user_picks"].format(self.id, gameweek)))
+                     for gameweek in range(1, self.current_event + 1)]
+            picks = await asyncio.gather(*tasks)
+            self._picks = picks
 
-        picks = await asyncio.gather(*tasks)
+        if gameweek:
+            valid_gameweek(gameweek)
+            return [next(pick["active_chip"] for pick in picks
+                         if pick["event"]["id"] == gameweek)]
 
-        return picks
+        return [pick["active_chip"] for pick in picks]
 
-    async def my_team(self):
+    async def get_automatic_substitutions(self, gameweek=None):
+        """Returns a list containing the user's automatic substitutions each
+        gameweek."""
+        if hasattr(self, "_picks"):
+            picks = self._picks
+        else:
+            tasks = [asyncio.ensure_future(
+                     fetch(self._session,
+                           API_URLS["user_picks"].format(self.id, gameweek)))
+                     for gameweek in range(1, self.current_event + 1)]
+            picks = await asyncio.gather(*tasks)
+            self._picks = picks
+
+        if gameweek:
+            valid_gameweek(gameweek)
+            return next(pick["automatic_subs"] for pick in picks
+                        if pick["event"]["id"] == gameweek)
+
+        return [pick["automatic_subs"] for pick in picks]
+
+    async def get_team(self):
         """Returns a logged in user's current team."""
         if not self._session:
             raise "User must be logged in."
@@ -154,138 +135,44 @@ class User():
 
         return response["picks"]
 
-    async def get_team(self, gameweek=None):
-        """Returns a list of all of the user's teams so far, or the user's team
-        in the specified gameweek.
-
-        :param int gameweek: A gameweek (1-38)
+    async def get_transfers(self, gameweek=None):
+        """Returns a list containing information about all the transfers the
+        user has made so far.
         """
-        try:
-            picks = self.picks
-        except:
-            picks = await self.get_picks()
+        if hasattr(self, "_transfers"):
+            return self._transfers["history"]
+
+        transfers = await fetch(
+            self._session, API_URLS["user_transfers"].format(self.id))
+
+        self._transfers = transfers
 
         if gameweek:
             valid_gameweek(gameweek)
-            return picks[gameweek]["picks"]
-
-        teams = []
-        for gameweek_id in range(1, self.current_gameweek):
-            team = picks[gameweek_id]["picks"]
-            teams.append(team)
-
-        return teams
-
-    async def get_chips(self, gameweek=None):
-        """Returns a list of chips used by the user so far, or the chip used
-        by the user in the specified gameweek.
-
-        :param int gameweek: A gameweek (1-38)
-        """
-        try:
-            picks = self.picks
-        except:
-            picks = await self.get_picks()
-
-        if gameweek:
-            valid_gameweek(gameweek)
-            return picks[gameweek]["active_chip"]
-
-        active_chips = []
-        for gameweek_id in range(1, self.current_gameweek):
-            active_chip = picks[gameweek_id]["active_chip"]
-            active_chips.append(active_chip)
-
-        return active_chips
-
-    async def get_automatic_substitutions(self, gameweek=None):
-        """Returns a list of all automatic substitions made for the user so
-        far, or the automatic substitutions made for the user in the specified
-        gameweek.
-
-        :param int gameweek: A gameweek (1-38)
-        """
-        try:
-            picks = self.picks
-        except:
-            picks = await self.get_picks()
-
-        if gameweek:
-            valid_gameweek(gameweek)
-            return picks[gameweek]["automatic_subs"]
-
-        automatic_substitutions = []
-        for gameweek_id in range(1, self.current_gameweek):
-            automatic_substitution = picks[gameweek_id]["automatic_subs"]
-            automatic_substitutions.append(automatic_substitution)
-
-        return automatic_substitutions
-
-    async def get_gameweek_history(self, gameweek=None):
-        """Returns a list of the user's history per gameweek, or the history
-        of a specific gameweek.
-
-        :param int gameweek: A gameweek (1-38)
-        """
-        try:
-            picks = self.picks
-        except:
-            picks = await self.get_picks()
-
-        if gameweek:
-            valid_gameweek(gameweek)
-            return picks[gameweek]["entry_history"]
-
-        histories = []
-        for gameweek_id in range(1, self.current_gameweek):
-            history = picks[gameweek_id]["entry_history"]
-            histories.append(history)
-
-        return histories
-
-    async def get_transfers(self):
-        """Returns a dictionary containing information about all the transfers
-        the user has made so far.
-        """
-        return await fetch(self._session, API_URLS["user_transfers"].format(
-            self.id))
-
-    async def get_wildcards(self):
-        """Returns a list containing information about the usage of the
-        player's wildcard(s).
-        """
-        try:
-            transfers = self.transfers
-        except:
-            transfers = await self.get_transfers()
-
-        return transfers["wildcards"]
-
-    async def get_transfer_history(self, gameweek=None):
-        """Returns a list containing information about the user's transfer
-        history.
-
-        :param int gameweek: A gameweek (1-38)
-        """
-        try:
-            transfers = self.transfers
-        except:
-            transfers = await self.get_transfers()
-
-        if gameweek:
-            valid_gameweek(gameweek)
-            transfers = [transfer for transfer in transfers["history"]
-                         if transfer["event"] == gameweek]
-            return transfers
+            return [transfer for transfer in transfers["history"]
+                    if transfer["event"] == gameweek]
 
         return transfers["history"]
 
-    def get_watchlist(self):
+    async def get_wildcards(self):
+        """Returns a list containing information about all the transfers the
+        user has made so far.
+        """
+        if hasattr(self, "_transfers"):
+            return self._transfers["wildcards"]
+
+        transfers = await fetch(
+            self._session, API_URLS["user_transfers"].format(self.id))
+
+        self._transfers = transfers
+        return transfers["wildcards"]
+
+    async def get_watchlist(self):
         """Returns the user's watchlist."""
         if not self._session:
             raise "User must be logged in."
 
-        return fetch(self._session, API_URLS["watchlist"])
+        return await fetch(self._session, API_URLS["watchlist"])
 
     def __str__(self):
         return "{} {} - {}".format(

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -13,10 +13,9 @@ def valid_gameweek(gameweek):
 
 class User():
     """A class representing a user of the Fantasy Premier League."""
-    def __init__(self, user_id, session):
-        self.user_id = user_id
+    def __init__(self, user_information, session):
         self._session = session
-        self._information = self._get_information()
+        self._information = user_information
         self._entry = self._information["entry"]
 
         #: The user's first name.
@@ -71,10 +70,6 @@ class User():
 
         #: Account deletion status.
         self.deleted = self._entry["deleted"]
-
-    def _get_information(self):
-        """Returns some general information about the user."""
-        return requests.get(API_URLS["user_cup"].format(self.user_id)).json()
 
     @property
     def history(self):

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -1,7 +1,7 @@
 import requests
 
 from ..constants import API_URLS
-from ..utils import team_converter
+from ..utils import team_converter, fetch
 
 
 def valid_gameweek(gameweek):
@@ -130,13 +130,13 @@ class User():
 
         return picks
 
-    def my_team(self):
+    async def my_team(self):
         """Returns a logged in user's current team."""
         if not self._session:
             raise "User must be logged in."
 
-        response = self._session.get(API_URLS["user_team"].format(
-            self.id)).json()
+        response = await fetch(
+            self._session, API_URLS["user_team"].format(self.id))
 
         if response == {"details": "You cannot view this entry"}:
             raise ValueError("User ID does not match provided email address!")

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -1,4 +1,9 @@
 
+async def fetch(session, url):
+    async with session.get(url) as response:
+        assert response.status == 200
+        return await response.json()
+
 
 def team_converter(team_id):
     """Converts a team's ID to their actual name."""

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -7,7 +7,7 @@ async def fetch(session, url):
                 return await response.json()
             await session.close()
         except Exception as error:
-            print(error)
+            pass
 
     session.close()
 

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -1,8 +1,15 @@
 
 async def fetch(session, url):
-    async with session.get(url) as response:
-        assert response.status == 200
-        return await response.json()
+    while True:
+        try:
+            async with session.get(url) as response:
+                assert response.status == 200
+                return await response.json()
+            await session.close()
+        except Exception as error:
+            print(error)
+
+    session.close()
 
 
 def team_converter(team_id):

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -83,7 +83,3 @@ def scale(value, upper, lower, min_, max_):
 def average(iterable):
     """Returns the average value of the iterable."""
     return sum(iterable) / float(len(iterable))
-
-
-def _run(coroutine):
-    return asyncio.get_event_loop().run_until_complete(coroutine)

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 
 async def fetch(session, url):
     while True:
@@ -8,8 +9,6 @@ async def fetch(session, url):
             await session.close()
         except Exception as error:
             pass
-
-    session.close()
 
 
 def team_converter(team_id):
@@ -74,3 +73,7 @@ def scale(value, upper, lower, min_, max_):
 def average(iterable):
     """Returns the average value of the iterable."""
     return sum(iterable) / float(len(iterable))
+
+
+def _run(coroutine):
+    return asyncio.get_event_loop().run_until_complete(coroutine)

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -11,6 +11,17 @@ async def fetch(session, url):
             pass
 
 
+async def get_current_gameweek(session):
+    """Returns the current gameweek.
+
+    :param aiohttp.ClientSession session: A logged in user's session
+    """
+    dynamic = await fetch(
+        session, "https://fantasy.premierleague.com/drf/bootstrap-dynamic")
+
+    return dynamic["entry"]["current_event"]
+
+
 def team_converter(team_id):
     """Converts a team's ID to their actual name."""
     team_map = {

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -23,7 +23,7 @@ def team_converter(team_id):
         18: "Watford",
         19: "West Ham",
         20: "Wolves",
-	None: None
+        None: None
     }
     return team_map[team_id]
 

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -6,7 +6,6 @@ async def fetch(session, url):
             async with session.get(url) as response:
                 assert response.status == 200
                 return await response.json()
-            await session.close()
         except Exception as error:
             pass
 

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 
+
 async def fetch(session, url):
     while True:
         try:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7"
     ],
@@ -22,6 +21,14 @@ setup(
         "Documentation": "http://fpl.readthedocs.io/en/latest/",
         "Source": "https://github.com/amosbastian/fpl"
     },
+    install_requires=[
+        "Click",
+        "colorama",
+        "PTable",
+        "appdirs",
+        "aiohttp",
+        "pytest-aiohttp",
+    ],
     entry_points="""
         [console_scripts]
         fpl=fpl.cli:cli

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="fpl",
-    version="0.5.5",
+    version="0.6.0",
     packages=find_packages(),
     description="A Python wrapper for the Fantasy Premier League API",
     url="https://github.com/amosbastian/fpl",

--- a/setup.py
+++ b/setup.py
@@ -13,25 +13,15 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6"
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7"
     ],
     keywords="fpl fantasy premier league",
     project_urls={
         "Documentation": "http://fpl.readthedocs.io/en/latest/",
         "Source": "https://github.com/amosbastian/fpl"
     },
-    install_requires=[
-        "Click",
-        "colorama",
-        "PTable",
-        "requests",
-        "pymongo",
-        "appdirs",
-    ],
     entry_points="""
         [console_scripts]
         fpl=fpl.cli:cli

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 from setuptools import setup, find_packages
 
+with open("README.md", "r") as f:
+    long_description = f.read()
+
 setup(
     name="fpl",
     version="0.6.0",
     packages=find_packages(),
     description="A Python wrapper for the Fantasy Premier League API",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/amosbastian/fpl",
     author="amosbastian",
     author_email="amosbastian@gmail.com",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import aiohttp
 import pytest
+
 from fpl import FPL
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,85 @@
+import aiohttp
+import pytest
+from fpl import FPL
+
+
+@pytest.fixture()
+async def fpl():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    yield fpl
+    await session.close()
+
+
+@pytest.fixture()
+async def classic_league():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    classic_league = await fpl.get_classic_league(633353)
+    yield classic_league
+    await session.close()
+
+
+@pytest.fixture()
+async def fixture():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    fixture = await fpl.get_fixture(6)
+    yield fixture
+    await session.close()
+
+
+@pytest.fixture()
+async def gameweek():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    gameweek = await fpl.get_gameweek(6)
+    yield gameweek
+    await session.close()
+
+
+@pytest.fixture()
+async def h2h_league():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    await fpl.login()
+    h2h_league = await fpl.get_h2h_league(760869)
+    yield h2h_league
+    await session.close()
+
+
+@pytest.fixture()
+async def player():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    player = await fpl.get_player(345, include_summary=True)
+    yield player
+    await session.close()
+
+
+@pytest.fixture()
+async def settings():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    settings = await fpl.get_settings()
+    yield settings
+    await session.close()
+
+
+@pytest.fixture()
+async def team():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    team = await fpl.get_team(14)
+    yield team
+    await session.close()
+
+
+@pytest.fixture()
+async def user():
+    session = aiohttp.ClientSession()
+    fpl = FPL(session)
+    await fpl.login()
+    user = await fpl.get_user(3808385)
+    yield user
+    await session.close()

--- a/tests/test_classic_league.py
+++ b/tests/test_classic_league.py
@@ -1,26 +1,22 @@
 import unittest
 
 from fpl import FPL
+from fpl.utils import _run
 
 
 class ClassicLeagueTest(unittest.TestCase):
     def setUp(self):
         self.fpl = FPL()
-        self.classic_league = self.fpl.get_classic_league("633353")
+        self.classic_league = _run(self.fpl.get_classic_league("633353"))
 
     def test_classic_league(self):
         self.assertEqual(
             self.classic_league.__str__(), "Steem Fantasy League - 633353")
 
-    def test__get_information(self):
-        information = self.classic_league._information
-        self.assertIsInstance(information, dict)
-
     def test_get_standings(self):
-        self.classic_league.get_standings()
-        standings = self.classic_league.standings
-        self.assertIsInstance(standings, list)
-        self.assertEqual(standings[0]["rank"], 1)
+        standings = _run(self.classic_league.get_standings(1))
+        self.assertIsInstance(standings, dict)
+        self.assertEqual(standings["results"][0]["rank"], 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_classic_league.py
+++ b/tests/test_classic_league.py
@@ -1,22 +1,8 @@
-import unittest
+class TestClassicLeague(object):
+    async def test_classic_league(self, loop, classic_league):
+        assert classic_league.__str__() == "Steem Fantasy League - 633353"
 
-from fpl import FPL
-from fpl.utils import _run
-
-
-class ClassicLeagueTest(unittest.TestCase):
-    def setUp(self):
-        self.fpl = FPL()
-        self.classic_league = _run(self.fpl.get_classic_league("633353"))
-
-    def test_classic_league(self):
-        self.assertEqual(
-            self.classic_league.__str__(), "Steem Fantasy League - 633353")
-
-    def test_get_standings(self):
-        standings = _run(self.classic_league.get_standings(1))
-        self.assertIsInstance(standings, dict)
-        self.assertEqual(standings["results"][0]["rank"], 1)
-
-if __name__ == '__main__':
-    unittest.main()
+    async def test_get_standings(self, loop, classic_league):
+        standings = await classic_league.get_standings(1)
+        assert isinstance(standings, dict)
+        assert standings["results"][0]["rank"] == 1

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,54 +1,40 @@
-import unittest
+class TestFixture(object):
+    def test_get_goalscorers(self, loop, fixture):
+        goalscorers = fixture.get_goalscorers()
+        assert isinstance(goalscorers, dict)
 
-from fpl import FPL
-from fpl.models.player import Player
-from fpl.utils import _run
+    def test_get_assisters(self, loop, fixture):
+        assisters = fixture.get_assisters()
+        assert isinstance(assisters, dict)
 
+    def test_get_own_goalscorers(self, loop, fixture):
+        own_goalscorers = fixture.get_own_goalscorers()
+        assert isinstance(own_goalscorers, dict)
 
-class FixtureTest(unittest.TestCase):
-    def setUp(self):
-        self.fpl = FPL()
-        self.fixture = _run(self.fpl.get_fixture(6))
+    def test_get_yellow_cards(self, loop, fixture):
+        yellow_cards = fixture.get_yellow_cards()
+        assert isinstance(yellow_cards, dict)
 
-    def test_get_goalscorers(self):
-        goalscorers = self.fixture.get_goalscorers()
-        self.assertIsInstance(goalscorers, dict)
+    def test_get_red_cards(self, loop, fixture):
+        red_cards = fixture.get_red_cards()
+        assert isinstance(red_cards, dict)
 
-    def test_get_assisters(self):
-        assisters = self.fixture.get_assisters()
-        self.assertIsInstance(assisters, dict)
+    def test_get_penalty_saves(self, loop, fixture):
+        penalty_saves = fixture.get_penalty_saves()
+        assert isinstance(penalty_saves, dict)
 
-    def test_get_own_goalscorers(self):
-        own_goalscorers = self.fixture.get_own_goalscorers()
-        self.assertIsInstance(own_goalscorers, dict)
+    def test_get_penalty_misses(self, loop, fixture):
+        penalty_misses = fixture.get_penalty_misses()
+        assert isinstance(penalty_misses, dict)
 
-    def test_get_yellow_cards(self):
-        yellow_cards = self.fixture.get_yellow_cards()
-        self.assertIsInstance(yellow_cards, dict)
+    def test_get_saves(self, loop, fixture):
+        saves = fixture.get_saves()
+        assert isinstance(saves, dict)
 
-    def test_get_red_cards(self):
-        red_cards = self.fixture.get_red_cards()
-        self.assertIsInstance(red_cards, dict)
+    def test_get_bonus(self, loop, fixture):
+        bonus = fixture.get_bonus()
+        assert isinstance(bonus, dict)
 
-    def test_get_penalty_saves(self):
-        penalty_saves = self.fixture.get_penalty_saves()
-        self.assertIsInstance(penalty_saves, dict)
-
-    def test_get_penalty_misses(self):
-        penalty_misses = self.fixture.get_penalty_misses()
-        self.assertIsInstance(penalty_misses, dict)
-
-    def test_get_saves(self):
-        saves = self.fixture.get_saves()
-        self.assertIsInstance(saves, dict)
-
-    def test_get_bonus(self):
-        bonus = self.fixture.get_bonus()
-        self.assertIsInstance(bonus, dict)
-
-    def test_get_bps(self):
-        bps = self.fixture.get_bps()
-        self.assertIsInstance(bps, dict)
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_get_bps(self, loop, fixture):
+        bps = fixture.get_bps()
+        assert isinstance(bps, dict)

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -2,82 +2,53 @@ import unittest
 
 from fpl import FPL
 from fpl.models.player import Player
+from fpl.utils import _run
 
 
 class FixtureTest(unittest.TestCase):
     def setUp(self):
         self.fpl = FPL()
-        self.fixture = self.fpl.get_fixture(6)
+        self.fixture = _run(self.fpl.get_fixture(6))
 
     def test_get_goalscorers(self):
-        self.fixture.get_goalscorers()
-        self.assertIsInstance(self.fixture.goalscorers, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.goalscorers[location]:
-                self.assertIsInstance(player["player"], Player)
+        goalscorers = self.fixture.get_goalscorers()
+        self.assertIsInstance(goalscorers, dict)
 
     def test_get_assisters(self):
-        self.fixture.get_assisters()
-        self.assertIsInstance(self.fixture.assisters, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.assisters[location]:
-                self.assertIsInstance(player["player"], Player)
+        assisters = self.fixture.get_assisters()
+        self.assertIsInstance(assisters, dict)
 
     def test_get_own_goalscorers(self):
-        self.fixture.get_own_goalscorers()
-        self.assertIsInstance(self.fixture.own_goalscorers, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.own_goalscorers[location]:
-                self.assertIsInstance(player["player"], Player)
+        own_goalscorers = self.fixture.get_own_goalscorers()
+        self.assertIsInstance(own_goalscorers, dict)
 
     def test_get_yellow_cards(self):
-        self.fixture.get_yellow_cards()
-        self.assertIsInstance(self.fixture.yellow_cards, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.yellow_cards[location]:
-                self.assertIsInstance(player["player"], Player)
+        yellow_cards = self.fixture.get_yellow_cards()
+        self.assertIsInstance(yellow_cards, dict)
 
     def test_get_red_cards(self):
-        self.fixture.get_red_cards()
-        self.assertIsInstance(self.fixture.red_cards, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.red_cards[location]:
-                self.assertIsInstance(player["player"], Player)
+        red_cards = self.fixture.get_red_cards()
+        self.assertIsInstance(red_cards, dict)
 
     def test_get_penalty_saves(self):
-        self.fixture.get_penalty_saves()
-        self.assertIsInstance(self.fixture.penalty_saves, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.penalty_saves[location]:
-                self.assertIsInstance(player["player"], Player)
+        penalty_saves = self.fixture.get_penalty_saves()
+        self.assertIsInstance(penalty_saves, dict)
 
     def test_get_penalty_misses(self):
-        self.fixture.get_penalty_misses()
-        self.assertIsInstance(self.fixture.penalty_misses, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.penalty_misses[location]:
-                self.assertIsInstance(player["player"], Player)
+        penalty_misses = self.fixture.get_penalty_misses()
+        self.assertIsInstance(penalty_misses, dict)
 
     def test_get_saves(self):
-        self.fixture.get_saves()
-        self.assertIsInstance(self.fixture.saves, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.saves[location]:
-                self.assertIsInstance(player["player"], Player)
+        saves = self.fixture.get_saves()
+        self.assertIsInstance(saves, dict)
 
     def test_get_bonus(self):
-        self.fixture.get_bonus()
-        self.assertIsInstance(self.fixture.bonus, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.bonus[location]:
-                self.assertIsInstance(player["player"], Player)
+        bonus = self.fixture.get_bonus()
+        self.assertIsInstance(bonus, dict)
 
     def test_get_bps(self):
-        self.fixture.get_bps()
-        self.assertIsInstance(self.fixture.bps, dict)
-        for location in ["away", "home"]:
-            for player in self.fixture.bps[location]:
-                self.assertIsInstance(player["player"], Player)
+        bps = self.fixture.get_bps()
+        self.assertIsInstance(bps, dict)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -142,8 +142,11 @@ class FPLTest(unittest.TestCase):
         self.assertIsInstance(classic_league, dict)
 
     def test_h2h_league(self):
-        h2h_league = self.fpl.get_h2h_league("760869")
+        h2h_league = _run(self.fpl.get_h2h_league("760869"))
         self.assertIsInstance(h2h_league, H2HLeague)
+
+        h2h_league = _run(self.fpl.get_h2h_league("760869", True))
+        self.assertIsInstance(h2h_league, dict)
 
     def test_update_mongodb(self):
         self.fpl.update_mongodb()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -41,10 +41,16 @@ class FPLTest(unittest.TestCase):
         self.assertEqual(len(teams), 20)
         self.assertIsInstance(teams[0], Team)
 
-        teams = _run(self.fpl.get_teams(True))
+        teams = _run(self.fpl.get_teams(return_json=True))
         self.assertIsInstance(teams, list)
         self.assertEqual(len(teams), 20)
         self.assertIsInstance(teams[0], dict)
+
+        teams = _run(self.fpl.get_teams(team_ids=[1, 2, 3]))
+        self.assertIsInstance(teams, list)
+        self.assertEqual(len(teams), 3)
+        self.assertIsInstance(teams[0], Team)
+        self.assertListEqual([team.id for team in teams], [1, 2, 3])
 
     def test_player(self):
         player = self.fpl.get_player(1)

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -88,10 +88,12 @@ class FPLTest(unittest.TestCase):
         self.assertEqual(len(players), 3)
 
     def test_fixture(self):
-        fixture = self.fpl.get_fixture(6)
+        fixture = _run(self.fpl.get_fixture(6))
         self.assertIsInstance(fixture, Fixture)
-        fixture = self.fpl.get_fixture(6, gameweek=1)
+        fixture = _run(self.fpl.get_fixture(6, gameweek=1))
         self.assertIsInstance(fixture, Fixture)
+        fixture = _run(self.fpl.get_fixture(6, gameweek=1, return_json=True))
+        self.assertIsInstance(fixture, dict)
 
     def test_fixtures(self):
         fixtures = self.fpl.get_fixtures()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -87,6 +87,10 @@ class FPLTest(unittest.TestCase):
         players = _run(self.fpl.get_players([1, 2, 3]))
         self.assertEqual(len(players), 3)
 
+        players = _run(self.fpl.get_players([1, 2, 3], True))
+        self.assertEqual(len(players), 3)
+        self.assertIsInstance(players[0].fixtures, list)
+
     def test_fixture(self):
         fixture = _run(self.fpl.get_fixture(6))
         self.assertIsInstance(fixture, Fixture)

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -134,8 +134,12 @@ class FPLTest(unittest.TestCase):
         self.assertIsInstance(game_settings, dict)
 
     def test_classic_league(self):
-        classic_league = self.fpl.get_classic_league("890172")
+        classic_league = _run(self.fpl.get_classic_league("890172"))
         self.assertIsInstance(classic_league, ClassicLeague)
+
+        classic_league = _run(
+            self.fpl.get_classic_league("890172", return_json=True))
+        self.assertIsInstance(classic_league, dict)
 
     def test_h2h_league(self):
         h2h_league = self.fpl.get_h2h_league("760869")

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -8,7 +8,7 @@ from fpl.models.classic_league import ClassicLeague
 from fpl.models.fixture import Fixture
 from fpl.models.gameweek import Gameweek
 from fpl.models.h2h_league import H2HLeague
-from fpl.models.player import Player
+from fpl.models.player import Player, PlayerSummary
 from fpl.models.team import Team
 from fpl.models.user import User
 
@@ -52,14 +52,40 @@ class FPLTest(unittest.TestCase):
         self.assertIsInstance(teams[0], Team)
         self.assertListEqual([team.id for team in teams], [1, 2, 3])
 
+    def test_player_summary(self):
+        player_summary = _run(self.fpl.get_player_summary(123))
+        self.assertIsInstance(player_summary, PlayerSummary)
+
+        player_summary = _run(self.fpl.get_player_summary(123, True))
+        self.assertIsInstance(player_summary, dict)
+
+    def test_player_summaries(self):
+        player_summaries = _run(self.fpl.get_player_summaries([1, 2, 3]))
+        self.assertIsInstance(player_summaries, list)
+        self.assertIsInstance(player_summaries[0], PlayerSummary)
+        self.assertEqual(len(player_summaries), 3)
+
+        player_summaries = _run(self.fpl.get_player_summaries([1, 2, 3], True))
+        self.assertIsInstance(player_summaries[0], dict)
+
     def test_player(self):
-        player = self.fpl.get_player(1)
+        player = _run(self.fpl.get_player(1))
         self.assertIsInstance(player, Player)
 
+        player = _run(self.fpl.get_player(1, True))
+        self.assertIsInstance(player, dict)
+
     def test_players(self):
-        players = self.fpl.get_players()
+        players = _run(self.fpl.get_players())
         self.assertIsInstance(players, list)
         self.assertIsInstance(players[0], Player)
+
+        players = _run(self.fpl.get_players(return_json=True))
+        self.assertIsInstance(players, list)
+        self.assertIsInstance(players[0], dict)
+
+        players = _run(self.fpl.get_players([1, 2, 3]))
+        self.assertEqual(len(players), 3)
 
     def test_fixture(self):
         fixture = self.fpl.get_fixture(6)

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -67,8 +67,13 @@ class FPLTest(unittest.TestCase):
         player = _run(self.fpl.get_player(1))
         self.assertIsInstance(player, Player)
 
-        player = _run(self.fpl.get_player(1, True))
+        player = _run(self.fpl.get_player(1, return_json=True))
         self.assertIsInstance(player, dict)
+
+        player_with_summary = _run(
+            self.fpl.get_player(1, include_summary=True))
+
+        self.assertIsInstance(player_with_summary.fixtures, list)
 
     def test_players(self):
         players = _run(self.fpl.get_players())
@@ -148,8 +153,8 @@ class FPLTest(unittest.TestCase):
             _run(self.fpl.login(123, 123))
         _run(self.fpl.login())
         user = _run(self.fpl.get_user(3808385))
-        my_team = _run(user.my_team())
-        self.assertIsInstance(my_team, list)
+        team = _run(user.get_team())
+        self.assertIsInstance(team, list)
 
     def test_points_against(self):
         points_against = _run(self.fpl.get_points_against())

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -90,19 +90,25 @@ class FPLTest(unittest.TestCase):
     def test_fixture(self):
         fixture = _run(self.fpl.get_fixture(6))
         self.assertIsInstance(fixture, Fixture)
+
         fixture = _run(self.fpl.get_fixture(6, gameweek=1))
         self.assertIsInstance(fixture, Fixture)
+
         fixture = _run(self.fpl.get_fixture(6, gameweek=1, return_json=True))
         self.assertIsInstance(fixture, dict)
 
     def test_fixtures(self):
-        fixtures = self.fpl.get_fixtures()
+        fixtures = _run(self.fpl.get_fixtures())
         self.assertIsInstance(fixtures, list)
         self.assertIsInstance(fixtures[0], Fixture)
-        fixtures = self.fpl.get_fixtures(gameweek=1)
+
+        fixtures = _run(self.fpl.get_fixtures(gameweek=1))
         self.assertEqual(len(fixtures), 10)
         self.assertIsInstance(fixtures, list)
         self.assertIsInstance(fixtures[0], Fixture)
+
+        fixtures = _run(self.fpl.get_fixtures(gameweek=1, return_json=True))
+        self.assertIsInstance(fixtures[0], dict)
 
     def test_gameweeks(self):
         gameweeks = self.fpl.get_gameweeks()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -29,8 +29,11 @@ class FPLTest(unittest.TestCase):
         self.assertIsInstance(user, dict)
 
     def test_team(self):
-        team = self.fpl.get_team(1)
+        team = _run(self.fpl.get_team(1))
         self.assertIsInstance(team, Team)
+
+        team = _run(self.fpl.get_team(1, True))
+        self.assertIsInstance(team, dict)
 
     def test_teams(self):
         teams = _run(self.fpl.get_teams())

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -122,8 +122,12 @@ class FPLTest(unittest.TestCase):
         self.assertIsInstance(gameweeks[0], dict)
 
     def test_gameweek(self):
-        gameweek = self.fpl.get_gameweek("20")
+        gameweek = _run(self.fpl.get_gameweek(20))
         self.assertIsInstance(gameweek, Gameweek)
+        self.assertEqual(gameweek.id, 20)
+
+        gameweek = _run(self.fpl.get_gameweek(20, return_json=True))
+        self.assertIsInstance(gameweek, dict)
 
     def test_game_settings(self):
         game_settings = self.fpl.game_settings()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -95,23 +95,41 @@ class FPLTest(unittest.TestCase):
         fixture = _run(self.fpl.get_fixture(6))
         self.assertIsInstance(fixture, Fixture)
 
-        fixture = _run(self.fpl.get_fixture(6, gameweek=1))
-        self.assertIsInstance(fixture, Fixture)
-
-        fixture = _run(self.fpl.get_fixture(6, gameweek=1, return_json=True))
+        fixture = _run(self.fpl.get_fixture(6, return_json=True))
         self.assertIsInstance(fixture, dict)
+
+    def test_fixtures_by_id(self):
+        fixtures = _run(self.fpl.get_fixtures_by_id([100, 200, 300]))
+        self.assertIsInstance(fixtures, list)
+        self.assertIsInstance(fixtures[0], Fixture)
+
+        fixtures = _run(
+            self.fpl.get_fixtures_by_id([100, 200, 300], return_json=True))
+        self.assertIsInstance(fixtures, list)
+        self.assertIsInstance(fixtures[0], dict)
+
+        fixture_ids = [fixture["id"] for fixture in fixtures]
+        self.assertListEqual([100, 200, 300], fixture_ids)
+
+    def test_fixtures_by_gameweek(self):
+        for gameweek in range(1, 39):
+            fixtures = _run(self.fpl.get_fixtures_by_gameweek(gameweek))
+            self.assertEqual(len(fixtures), 10)
+            self.assertIsInstance(fixtures, list)
+            self.assertIsInstance(fixtures[0], Fixture)
+            # self.assertEqual(fixtures[0].event, gameweek)
+
+            fixtures = _run(
+                self.fpl.get_fixtures_by_gameweek(gameweek, return_json=True))
+            self.assertIsInstance(fixtures[0], dict)
 
     def test_fixtures(self):
         fixtures = _run(self.fpl.get_fixtures())
+        self.assertEqual(len(fixtures), 380)
         self.assertIsInstance(fixtures, list)
         self.assertIsInstance(fixtures[0], Fixture)
 
-        fixtures = _run(self.fpl.get_fixtures(gameweek=1))
-        self.assertEqual(len(fixtures), 10)
-        self.assertIsInstance(fixtures, list)
-        self.assertIsInstance(fixtures[0], Fixture)
-
-        fixtures = _run(self.fpl.get_fixtures(gameweek=1, return_json=True))
+        fixtures = _run(self.fpl.get_fixtures(return_json=True))
         self.assertIsInstance(fixtures[0], dict)
 
     def test_gameweeks(self):

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -111,9 +111,15 @@ class FPLTest(unittest.TestCase):
         self.assertIsInstance(fixtures[0], dict)
 
     def test_gameweeks(self):
-        gameweeks = self.fpl.get_gameweeks()
+        gameweeks = _run(self.fpl.get_gameweeks())
         self.assertIsInstance(gameweeks, list)
         self.assertEqual(len(gameweeks), 38)
+        self.assertIsInstance(gameweeks[0], Gameweek)
+
+        gameweeks = _run(self.fpl.get_gameweeks([1, 2, 3], return_json=True))
+        self.assertIsInstance(gameweeks, list)
+        self.assertEqual(len(gameweeks), 3)
+        self.assertIsInstance(gameweeks[0], dict)
 
     def test_gameweek(self):
         gameweek = self.fpl.get_gameweek("20")

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -154,6 +154,10 @@ class FPLTest(unittest.TestCase):
         my_team = _run(user.my_team())
         self.assertIsInstance(my_team, list)
 
+    def test_points_against(self):
+        points_against = _run(self.fpl.get_points_against())
+        self.assertIsInstance(points_against, dict)
+
     def test_FDR(self):
         def test_main(fdr):
             self.assertIsInstance(fdr, dict)

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -130,7 +130,7 @@ class FPLTest(unittest.TestCase):
         self.assertIsInstance(gameweek, dict)
 
     def test_game_settings(self):
-        game_settings = self.fpl.game_settings()
+        game_settings = _run(self.fpl.game_settings())
         self.assertIsInstance(game_settings, dict)
 
     def test_classic_league(self):
@@ -147,6 +147,14 @@ class FPLTest(unittest.TestCase):
 
         h2h_league = _run(self.fpl.get_h2h_league("760869", True))
         self.assertIsInstance(h2h_league, dict)
+
+    def test_login(self):
+        with self.assertRaises(ValueError):
+            _run(self.fpl.login(123, 123))
+        _run(self.fpl.login())
+        user = _run(self.fpl.get_user(3808385))
+        my_team = _run(user.my_team())
+        self.assertIsInstance(my_team, list)
 
     def test_update_mongodb(self):
         self.fpl.update_mongodb()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -9,10 +9,7 @@ from fpl.models.h2h_league import H2HLeague
 from fpl.models.player import Player, PlayerSummary
 from fpl.models.team import Team
 from fpl.models.user import User
-
-
-def _run(coroutine):
-    return asyncio.get_event_loop().run_until_complete(coroutine)
+from fpl.utils import _run
 
 
 class FPLTest(unittest.TestCase):
@@ -177,7 +174,6 @@ class FPLTest(unittest.TestCase):
         def test_default():
             fdr = self.fpl.FDR()
             test_main(fdr)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -33,10 +33,15 @@ class FPLTest(unittest.TestCase):
         self.assertIsInstance(team, Team)
 
     def test_teams(self):
-        teams = self.fpl.get_teams()
+        teams = _run(self.fpl.get_teams())
         self.assertIsInstance(teams, list)
         self.assertEqual(len(teams), 20)
         self.assertIsInstance(teams[0], Team)
+
+        teams = _run(self.fpl.get_teams(True))
+        self.assertIsInstance(teams, list)
+        self.assertEqual(len(teams), 20)
+        self.assertIsInstance(teams[0], dict)
 
     def test_player(self):
         player = self.fpl.get_player(1)

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -1,5 +1,4 @@
-import asyncio
-import unittest
+import pytest
 
 from fpl import FPL
 from fpl.models.classic_league import ClassicLeague
@@ -9,183 +8,177 @@ from fpl.models.h2h_league import H2HLeague
 from fpl.models.player import Player, PlayerSummary
 from fpl.models.team import Team
 from fpl.models.user import User
-from fpl.utils import _run
 
 
-class FPLTest(unittest.TestCase):
-    def setUp(self):
-        self.fpl = FPL()
+class TestFPL(object):
+    async def test_user(self, loop, fpl):
+        user = await fpl.get_user("3523615")
+        assert isinstance(user, User)
 
-    def test_user(self):
-        user = _run(self.fpl.get_user("3523615"))
-        self.assertIsInstance(user, User)
+        user = await fpl.get_user("3523615", True)
+        assert isinstance(user, dict)
 
-        user = _run(self.fpl.get_user("3523615", True))
-        self.assertIsInstance(user, dict)
+    async def test_team(self, loop, fpl):
+        team = await fpl.get_team(1)
+        assert isinstance(team, Team)
 
-    def test_team(self):
-        team = _run(self.fpl.get_team(1))
-        self.assertIsInstance(team, Team)
+        team = await fpl.get_team(1, True)
+        assert isinstance(team, dict)
 
-        team = _run(self.fpl.get_team(1, True))
-        self.assertIsInstance(team, dict)
+    async def test_teams(self, loop, fpl):
+        teams = await fpl.get_teams()
+        assert isinstance(teams, list)
+        assert len(teams) == 20
+        assert isinstance(teams[0], Team)
 
-    def test_teams(self):
-        teams = _run(self.fpl.get_teams())
-        self.assertIsInstance(teams, list)
-        self.assertEqual(len(teams), 20)
-        self.assertIsInstance(teams[0], Team)
+        teams = await fpl.get_teams(return_json=True)
+        assert isinstance(teams, list)
+        assert len(teams) == 20
+        assert isinstance(teams[0], dict)
 
-        teams = _run(self.fpl.get_teams(return_json=True))
-        self.assertIsInstance(teams, list)
-        self.assertEqual(len(teams), 20)
-        self.assertIsInstance(teams[0], dict)
+        teams = await fpl.get_teams(team_ids=[1, 2, 3])
+        assert isinstance(teams, list)
+        assert len(teams) == 3
+        assert isinstance(teams[0], Team)
+        assert [team.id for team in teams] == [1, 2, 3]
 
-        teams = _run(self.fpl.get_teams(team_ids=[1, 2, 3]))
-        self.assertIsInstance(teams, list)
-        self.assertEqual(len(teams), 3)
-        self.assertIsInstance(teams[0], Team)
-        self.assertListEqual([team.id for team in teams], [1, 2, 3])
+    async def test_player_summary(self, loop, fpl):
+        player_summary = await fpl.get_player_summary(123)
+        assert isinstance(player_summary, PlayerSummary)
 
-    def test_player_summary(self):
-        player_summary = _run(self.fpl.get_player_summary(123))
-        self.assertIsInstance(player_summary, PlayerSummary)
+        player_summary = await fpl.get_player_summary(123, True)
+        assert isinstance(player_summary, dict)
 
-        player_summary = _run(self.fpl.get_player_summary(123, True))
-        self.assertIsInstance(player_summary, dict)
+    async def test_player_summaries(self, loop, fpl):
+        player_summaries = await fpl.get_player_summaries([1, 2, 3])
+        assert isinstance(player_summaries, list)
+        assert isinstance(player_summaries[0], PlayerSummary)
+        assert len(player_summaries) == 3
 
-    def test_player_summaries(self):
-        player_summaries = _run(self.fpl.get_player_summaries([1, 2, 3]))
-        self.assertIsInstance(player_summaries, list)
-        self.assertIsInstance(player_summaries[0], PlayerSummary)
-        self.assertEqual(len(player_summaries), 3)
+        player_summaries = await fpl.get_player_summaries([1, 2, 3], True)
+        assert isinstance(player_summaries[0], dict)
 
-        player_summaries = _run(self.fpl.get_player_summaries([1, 2, 3], True))
-        self.assertIsInstance(player_summaries[0], dict)
+    async def test_player(self, loop, fpl):
+        player = await fpl.get_player(1)
+        assert isinstance(player, Player)
 
-    def test_player(self):
-        player = _run(self.fpl.get_player(1))
-        self.assertIsInstance(player, Player)
+        player = await fpl.get_player(1, return_json=True)
+        assert isinstance(player, dict)
 
-        player = _run(self.fpl.get_player(1, return_json=True))
-        self.assertIsInstance(player, dict)
+        player_with_summary = await fpl.get_player(1, include_summary=True)
 
-        player_with_summary = _run(
-            self.fpl.get_player(1, include_summary=True))
+        assert isinstance(player_with_summary.fixtures, list)
 
-        self.assertIsInstance(player_with_summary.fixtures, list)
+    async def test_players(self, loop, fpl):
+        players = await fpl.get_players()
+        assert isinstance(players, list)
+        assert isinstance(players[0], Player)
 
-    def test_players(self):
-        players = _run(self.fpl.get_players())
-        self.assertIsInstance(players, list)
-        self.assertIsInstance(players[0], Player)
+        players = await fpl.get_players(return_json=True)
+        assert isinstance(players, list)
+        assert isinstance(players[0], dict)
 
-        players = _run(self.fpl.get_players(return_json=True))
-        self.assertIsInstance(players, list)
-        self.assertIsInstance(players[0], dict)
+        players = await fpl.get_players([1, 2, 3])
+        assert len(players) == 3
 
-        players = _run(self.fpl.get_players([1, 2, 3]))
-        self.assertEqual(len(players), 3)
+        players = await fpl.get_players([1, 2, 3], True)
+        assert len(players) == 3
+        assert isinstance(players[0].fixtures, list)
 
-        players = _run(self.fpl.get_players([1, 2, 3], True))
-        self.assertEqual(len(players), 3)
-        self.assertIsInstance(players[0].fixtures, list)
+    async def test_fixture(self, loop, fpl):
+        fixture = await fpl.get_fixture(6)
+        assert isinstance(fixture, Fixture)
 
-    def test_fixture(self):
-        fixture = _run(self.fpl.get_fixture(6))
-        self.assertIsInstance(fixture, Fixture)
+        fixture = await fpl.get_fixture(6, return_json=True)
+        assert isinstance(fixture, dict)
 
-        fixture = _run(self.fpl.get_fixture(6, return_json=True))
-        self.assertIsInstance(fixture, dict)
+    async def test_fixtures_by_id(self, loop, fpl):
+        fixtures = await fpl.get_fixtures_by_id([100, 200, 300])
+        assert isinstance(fixtures, list)
+        assert isinstance(fixtures[0], Fixture)
 
-    def test_fixtures_by_id(self):
-        fixtures = _run(self.fpl.get_fixtures_by_id([100, 200, 300]))
-        self.assertIsInstance(fixtures, list)
-        self.assertIsInstance(fixtures[0], Fixture)
-
-        fixtures = _run(
-            self.fpl.get_fixtures_by_id([100, 200, 300], return_json=True))
-        self.assertIsInstance(fixtures, list)
-        self.assertIsInstance(fixtures[0], dict)
+        fixtures = await fpl.get_fixtures_by_id(
+            [100, 200, 300], return_json=True)
+        assert isinstance(fixtures, list)
+        assert isinstance(fixtures[0], dict)
 
         fixture_ids = [fixture["id"] for fixture in fixtures]
-        self.assertListEqual([100, 200, 300], fixture_ids)
+        assert [100, 200, 300] == fixture_ids
 
-    def test_fixtures_by_gameweek(self):
+    async def test_fixtures_by_gameweek(self, loop, fpl):
         for gameweek in range(1, 39):
-            fixtures = _run(self.fpl.get_fixtures_by_gameweek(gameweek))
-            self.assertEqual(len(fixtures), 10)
-            self.assertIsInstance(fixtures, list)
-            self.assertIsInstance(fixtures[0], Fixture)
-            # self.assertEqual(fixtures[0].event, gameweek)
+            fixtures = await fpl.get_fixtures_by_gameweek(gameweek)
+            assert len(fixtures) == 10
+            assert isinstance(fixtures, list)
+            assert isinstance(fixtures[0], Fixture)
 
-            fixtures = _run(
-                self.fpl.get_fixtures_by_gameweek(gameweek, return_json=True))
-            self.assertIsInstance(fixtures[0], dict)
+            fixtures = await fpl.get_fixtures_by_gameweek(
+                gameweek, return_json=True)
+            assert isinstance(fixtures[0], dict)
 
-    def test_fixtures(self):
-        fixtures = _run(self.fpl.get_fixtures())
-        self.assertEqual(len(fixtures), 380)
-        self.assertIsInstance(fixtures, list)
-        self.assertIsInstance(fixtures[0], Fixture)
+    async def test_fixtures(self, loop, fpl):
+        fixtures = await fpl.get_fixtures()
+        assert len(fixtures) == 380
+        assert isinstance(fixtures, list)
+        assert isinstance(fixtures[0], Fixture)
 
-        fixtures = _run(self.fpl.get_fixtures(return_json=True))
-        self.assertIsInstance(fixtures[0], dict)
+        fixtures = await fpl.get_fixtures(return_json=True)
+        assert isinstance(fixtures[0], dict)
 
-    def test_gameweeks(self):
-        gameweeks = _run(self.fpl.get_gameweeks())
-        self.assertIsInstance(gameweeks, list)
-        self.assertEqual(len(gameweeks), 38)
-        self.assertIsInstance(gameweeks[0], Gameweek)
+    async def test_gameweeks(self, loop, fpl):
+        gameweeks = await fpl.get_gameweeks()
+        assert isinstance(gameweeks, list)
+        assert len(gameweeks) == 38
+        assert isinstance(gameweeks[0], Gameweek)
 
-        gameweeks = _run(self.fpl.get_gameweeks([1, 2, 3], return_json=True))
-        self.assertIsInstance(gameweeks, list)
-        self.assertEqual(len(gameweeks), 3)
-        self.assertIsInstance(gameweeks[0], dict)
+        gameweeks = await fpl.get_gameweeks([1, 2, 3], return_json=True)
+        assert isinstance(gameweeks, list)
+        assert len(gameweeks) == 3
+        assert isinstance(gameweeks[0], dict)
 
-    def test_gameweek(self):
-        gameweek = _run(self.fpl.get_gameweek(20))
-        self.assertIsInstance(gameweek, Gameweek)
-        self.assertEqual(gameweek.id, 20)
+    async def test_gameweek(self, loop, fpl):
+        gameweek = await fpl.get_gameweek(20)
+        assert isinstance(gameweek, Gameweek)
+        assert gameweek.id == 20
 
-        gameweek = _run(self.fpl.get_gameweek(20, return_json=True))
-        self.assertIsInstance(gameweek, dict)
+        gameweek = await fpl.get_gameweek(20, return_json=True)
+        assert isinstance(gameweek, dict)
 
-    def test_game_settings(self):
-        game_settings = _run(self.fpl.game_settings())
-        self.assertIsInstance(game_settings, dict)
+    async def test_game_settings(self, loop, fpl):
+        game_settings = await fpl.game_settings()
+        assert isinstance(game_settings, dict)
 
-    def test_classic_league(self):
-        classic_league = _run(self.fpl.get_classic_league("890172"))
-        self.assertIsInstance(classic_league, ClassicLeague)
+    async def test_classic_league(self, loop, fpl):
+        classic_league = await fpl.get_classic_league(890172)
+        assert isinstance(classic_league, ClassicLeague)
 
-        classic_league = _run(
-            self.fpl.get_classic_league("890172", return_json=True))
-        self.assertIsInstance(classic_league, dict)
+        classic_league = await fpl.get_classic_league(890172, return_json=True)
+        assert isinstance(classic_league, dict)
 
-    def test_h2h_league(self):
-        h2h_league = _run(self.fpl.get_h2h_league("760869"))
-        self.assertIsInstance(h2h_league, H2HLeague)
+    async def test_h2h_league(self, loop, fpl):
+        h2h_league = await fpl.get_h2h_league(760869)
+        assert isinstance(h2h_league, H2HLeague)
 
-        h2h_league = _run(self.fpl.get_h2h_league("760869", True))
-        self.assertIsInstance(h2h_league, dict)
+        h2h_league = await fpl.get_h2h_league(760869, True)
+        assert isinstance(h2h_league, dict)
 
-    def test_login(self):
-        with self.assertRaises(ValueError):
-            _run(self.fpl.login(123, 123))
-        _run(self.fpl.login())
-        user = _run(self.fpl.get_user(3808385))
-        team = _run(user.get_team())
-        self.assertIsInstance(team, list)
+    async def test_login(self, loop, fpl):
+        with pytest.raises(ValueError):
+            await fpl.login(123, 123)
 
-    def test_points_against(self):
-        points_against = _run(self.fpl.get_points_against())
-        self.assertIsInstance(points_against, dict)
+        await fpl.login()
+        user = await fpl.get_user(3808385)
+        team = await user.get_team()
+        assert isinstance(team, list)
 
-    def test_FDR(self):
+    async def test_points_against(self, loop, fpl):
+        points_against = await fpl.get_points_against()
+        assert isinstance(points_against, dict)
+
+    async def test_FDR(self, loop, fpl):
         def test_main(fdr):
-            self.assertIsInstance(fdr, dict)
-            self.assertEqual(len(fdr), 20)
+            assert isinstance(fdr, dict)
+            assert len(fdr) == 20
 
             location_extrema = {"H": [], "A": []}
             for team, positions in fdr.items():
@@ -193,14 +186,10 @@ class FPLTest(unittest.TestCase):
                     location_extrema["H"].append(location["H"])
                     location_extrema["A"].append(location["A"])
 
-            self.assertEqual(max(location_extrema["H"]), 5.0)
-            self.assertEqual(min(location_extrema["H"]), 1.0)
-            self.assertEqual(max(location_extrema["A"]), 5.0)
-            self.assertEqual(min(location_extrema["A"]), 1.0)
+            assert max(location_extrema["H"]) == 5.0
+            assert min(location_extrema["H"]) == 1.0
+            assert max(location_extrema["A"]) == 5.0
+            assert min(location_extrema["A"]) == 1.0
 
-        def test_default():
-            fdr = self.fpl.FDR()
-            test_main(fdr)
-
-if __name__ == '__main__':
-    unittest.main()
+        fdr = await fpl.FDR()
+        test_main(fdr)

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -1,8 +1,6 @@
 import asyncio
 import unittest
 
-from pymongo import MongoClient
-
 from fpl import FPL
 from fpl.models.classic_league import ClassicLeague
 from fpl.models.fixture import Fixture
@@ -156,27 +154,6 @@ class FPLTest(unittest.TestCase):
         my_team = _run(user.my_team())
         self.assertIsInstance(my_team, list)
 
-    def test_update_mongodb(self):
-        self.fpl.update_mongodb()
-        client = MongoClient()
-        database = client.fpl
-
-        teams = database.teams.find()
-        self.assertEqual(teams.count(), 20)
-        team = database.teams.find_one({"team_id": 1})
-        self.assertIsInstance(team["fixtures"], list)
-        self.assertTrue("FDR" in team.keys())
-        self.assertTrue(len(team["fixtures"]) > 0)
-        self.assertTrue("FDR" in team["fixtures"][0].keys())
-
-        player = database.players.find_one({"player_id": 1})
-        self.assertEqual(player["player_id"], 1)
-
-    def test_get_points_against(self):
-        points_against = self.fpl.get_points_against()
-        self.assertIsInstance(points_against, dict)
-        self.assertEqual(len(points_against), 20)
-
     def test_FDR(self):
         def test_main(fdr):
             self.assertIsInstance(fdr, dict)
@@ -197,9 +174,6 @@ class FPLTest(unittest.TestCase):
             fdr = self.fpl.FDR()
             test_main(fdr)
 
-        def test_mongodb():
-            fdr = self.fpl.FDR(True)
-            test_main(fdr)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -1,4 +1,7 @@
+import asyncio
 import unittest
+
+from pymongo import MongoClient
 
 from fpl import FPL
 from fpl.models.classic_league import ClassicLeague
@@ -8,7 +11,10 @@ from fpl.models.h2h_league import H2HLeague
 from fpl.models.player import Player
 from fpl.models.team import Team
 from fpl.models.user import User
-from pymongo import MongoClient
+
+
+def _run(coroutine):
+    return asyncio.get_event_loop().run_until_complete(coroutine)
 
 
 class FPLTest(unittest.TestCase):
@@ -16,8 +22,11 @@ class FPLTest(unittest.TestCase):
         self.fpl = FPL()
 
     def test_user(self):
-        user = self.fpl.get_user("3523615")
+        user = _run(self.fpl.get_user("3523615"))
         self.assertIsInstance(user, User)
+
+        user = _run(self.fpl.get_user("3523615", True))
+        self.assertIsInstance(user, dict)
 
     def test_team(self):
         team = self.fpl.get_team(1)

--- a/tests/test_gameweek.py
+++ b/tests/test_gameweek.py
@@ -1,21 +1,6 @@
-import unittest
+class TestGameweek(object):
+    def test_gameweek(self, loop, gameweek):
+        assert gameweek.__str__() == "Gameweek 6 - 22 Sep 11:30"
 
-from fpl import FPL
-from fpl.models.player import Player
-from fpl.utils import _run
-
-
-class GameweekTest(unittest.TestCase):
-    def setUp(self):
-        self.fpl = FPL()
-        self.gameweek = _run(self.fpl.get_gameweek(1))
-
-    def test_gameweek(self):
-        self.assertEqual(
-            self.gameweek.__str__(), "Gameweek 1 - 10 Aug 19:00")
-
-    def test_fixtures(self):
-        self.assertIsInstance(self.gameweek.fixtures, list)
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_fixtures(self, loop, gameweek):
+        assert isinstance(gameweek.fixtures, list)

--- a/tests/test_gameweek.py
+++ b/tests/test_gameweek.py
@@ -2,24 +2,20 @@ import unittest
 
 from fpl import FPL
 from fpl.models.player import Player
+from fpl.utils import _run
 
 
 class GameweekTest(unittest.TestCase):
     def setUp(self):
         self.fpl = FPL()
-        self.gameweek = self.fpl.get_gameweek(1)
+        self.gameweek = _run(self.fpl.get_gameweek(1))
 
     def test_gameweek(self):
         self.assertEqual(
-            self.gameweek.__str__(), "Gameweek 1 - 2018-08-10T18:00:00Z")
+            self.gameweek.__str__(), "Gameweek 1 - 10 Aug 19:00")
 
     def test_fixtures(self):
         self.assertIsInstance(self.gameweek.fixtures, list)
-
-    def test_get_players(self):
-        self.gameweek.get_players()
-        self.assertIsInstance(self.gameweek.players, list)
-        self.assertIsInstance(self.gameweek.players[0], Player)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_h2h_league.py
+++ b/tests/test_h2h_league.py
@@ -1,23 +1,8 @@
-import unittest
+class TestH2HLeague(object):
+    def test_h2h_league(self, loop, h2h_league):
+        assert h2h_league.__str__() == "League 760869 - 760869"
 
-from fpl import FPL
-from fpl.utils import _run
-
-
-class H2HLeagueTest(unittest.TestCase):
-    def setUp(self):
-        self.fpl = FPL()
-        _run(self.fpl.login())
-        self.h2h_league = _run(self.fpl.get_h2h_league("760869"))
-
-    def test_h2h_league(self):
-        self.assertEqual(
-            self.h2h_league.__str__(), "League 760869 - 760869")
-
-    def test_fixtures(self):
-        fixtures = _run(self.h2h_league.get_fixtures())
-        self.assertIsInstance(fixtures, list)
-        self.assertIsInstance(fixtures[0], dict)
-
-if __name__ == '__main__':
-    unittest.main()
+    async def test_fixtures(self, loop, h2h_league):
+        fixtures = await h2h_league.get_fixtures()
+        assert isinstance(fixtures, list)
+        assert isinstance(fixtures[0], dict)

--- a/tests/test_h2h_league.py
+++ b/tests/test_h2h_league.py
@@ -1,27 +1,23 @@
 import unittest
 
 from fpl import FPL
+from fpl.utils import _run
 
 
 class H2HLeagueTest(unittest.TestCase):
     def setUp(self):
         self.fpl = FPL()
-        self.fpl.login()
-        self.h2h_league = self.fpl.get_h2h_league("760869")
+        _run(self.fpl.login())
+        self.h2h_league = _run(self.fpl.get_h2h_league("760869"))
 
     def test_h2h_league(self):
         self.assertEqual(
             self.h2h_league.__str__(), "League 760869 - 760869")
 
-    def test__get_information(self):
-        information = self.h2h_league._information
-        self.assertIsInstance(information, dict)
-
-    def test_get_standings(self):
-        self.h2h_league.get_fixtures()
-        fixtures = self.h2h_league.fixtures
+    def test_fixtures(self):
+        fixtures = _run(self.h2h_league.get_fixtures())
         self.assertIsInstance(fixtures, list)
-        self.assertEqual(fixtures[0]["event"], 1)
+        self.assertIsInstance(fixtures[0], dict)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,12 +1,13 @@
 import unittest
 
 from fpl import FPL
+from fpl.utils import _run
 
 
 class FPLTest(unittest.TestCase):
     def setUp(self):
         self.fpl = FPL()
-        self.player = self.fpl.get_player(1)
+        self.player = _run(self.fpl.get_player(1))
 
     def test_games_played(self):
         pass

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,20 +1,8 @@
-import unittest
+class TestPlayer(object):
+    def test_games_played(self, loop, player):
+        games_played = player.games_played
+        assert isinstance(games_played, int)
 
-from fpl import FPL
-from fpl.utils import _run
-
-
-class FPLTest(unittest.TestCase):
-    def setUp(self):
-        self.fpl = FPL()
-        self.player = _run(self.fpl.get_player(1))
-
-    def test_games_played(self):
-        pass
-
-    def test_pp90(self):
-        pass
-
-
-if __name__ == '__main__':
-    unittest.main()
+    def test_pp90(self, loop, player):
+        pp90 = player.pp90
+        assert isinstance(pp90, float)

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -2,27 +2,32 @@ import unittest
 
 from fpl import FPL
 from fpl.models.player import Player
+from fpl.utils import _run
 
 
 class TeamTest(unittest.TestCase):
     def setUp(self):
         self.fpl = FPL()
-        self.team = self.fpl.get_team(1)
+        self.team = _run(self.fpl.get_team(1))
 
     def test_team(self):
         self.assertEqual(self.team.__str__(), self.team.name)
 
-    def test__get_information(self):
-        information = self.team._get_information()
-        self.assertIsInstance(information, dict)
-
     def test_get_players(self):
-        self.team.get_players()
-        self.assertIsInstance(self.team.players, list)
-        self.assertIsInstance(self.team.players[0], Player)
+        players = _run(self.team.get_players())
+        self.assertIsInstance(players, list)
+        self.assertIsInstance(players[0], Player)
+
+        players = _run(self.team.get_players(return_json=True))
+        self.assertIsInstance(players, list)
+        self.assertIsInstance(players[0], dict)
 
     def test_get_fixtures(self):
-        self.team.get_fixtures()
+        fixtures = _run(self.team.get_fixtures())
+        self.assertIsInstance(self.team.fixtures, list)
+        self.assertTrue(len(self.team.fixtures) > 0)
+
+        fixtures = _run(self.team.get_fixtures(return_json=True))
         self.assertIsInstance(self.team.fixtures, list)
         self.assertTrue(len(self.team.fixtures) > 0)
 

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -1,35 +1,24 @@
-import unittest
-
-from fpl import FPL
 from fpl.models.player import Player
-from fpl.utils import _run
 
 
-class TeamTest(unittest.TestCase):
-    def setUp(self):
-        self.fpl = FPL()
-        self.team = _run(self.fpl.get_team(1))
+class TestTeam(object):
+    def test_team(self, loop, team):
+        assert team.__str__() == team.name
 
-    def test_team(self):
-        self.assertEqual(self.team.__str__(), self.team.name)
+    async def test_get_players(self, loop, team):
+        players = await team.get_players()
+        assert isinstance(players, list)
+        assert isinstance(players[0], Player)
 
-    def test_get_players(self):
-        players = _run(self.team.get_players())
-        self.assertIsInstance(players, list)
-        self.assertIsInstance(players[0], Player)
+        players = await team.get_players(return_json=True)
+        assert isinstance(players, list)
+        assert isinstance(players[0], dict)
 
-        players = _run(self.team.get_players(return_json=True))
-        self.assertIsInstance(players, list)
-        self.assertIsInstance(players[0], dict)
+    async def test_get_fixtures(self, loop, team):
+        fixtures = await team.get_fixtures()
+        assert isinstance(team.fixtures, list)
+        assert len(team.fixtures) > 0
 
-    def test_get_fixtures(self):
-        fixtures = _run(self.team.get_fixtures())
-        self.assertIsInstance(self.team.fixtures, list)
-        self.assertTrue(len(self.team.fixtures) > 0)
-
-        fixtures = _run(self.team.get_fixtures(return_json=True))
-        self.assertIsInstance(self.team.fixtures, list)
-        self.assertTrue(len(self.team.fixtures) > 0)
-
-if __name__ == '__main__':
-    unittest.main()
+        fixtures = await team.get_fixtures(return_json=True)
+        assert isinstance(team.fixtures, list)
+        assert len(team.fixtures) > 0

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -56,8 +56,8 @@ class UserTest(unittest.TestCase):
         self.assertIsInstance(automatic_substitutions, list)
 
     def test_team(self):
-        my_team = _run(self.user.get_team())
-        self.assertIsInstance(my_team, list)
+        team = _run(self.user.get_team())
+        self.assertIsInstance(team, list)
 
     def test_transfers(self):
         transfers = _run(self.user.get_transfers())

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -10,8 +10,11 @@ class UserTest(unittest.TestCase):
         _run(self.fpl.login())
         self.user = _run(self.fpl.get_user("3808385"))
 
-    def test_history(self):
-        history = _run(self.user.get_history())
+    def test_gameweek_history(self):
+        history = _run(self.user.get_gameweek_history())
+        self.assertIsInstance(history, list)
+
+        history = _run(self.user.get_gameweek_history(1))
         self.assertIsInstance(history, dict)
 
     def test_season_history(self):
@@ -23,64 +26,49 @@ class UserTest(unittest.TestCase):
         self.assertIsInstance(chips, list)
 
     def test_leagues(self):
-        leagues = _run(self.user.get_leagues())
+        leagues = self.user.leagues
         self.assertIsInstance(leagues, dict)
-
-    def test_classic(self):
-        classic = _run(self.user.get_classic_leagues())
-        self.assertIsInstance(classic, list)
-
-    def test_h2h(self):
-        h2h = _run(self.user.get_h2h_leagues())
-        self.assertIsInstance(h2h, list)
 
     def test_picks(self):
         picks = _run(self.user.get_picks())
         self.assertIsInstance(picks, list)
-        self.assertEqual(len(picks), self.user.current_gameweek)
+        self.assertEqual(len(picks), self.user.current_event)
 
-    def test_my_team(self):
-        my_team = _run(self.user.my_team())
-        self.assertIsInstance(my_team, list)
+        picks = _run(self.user.get_picks(1))
+        self.assertIsInstance(picks, list)
 
-    def test_team(self):
-        team = _run(self.user.get_team())
-        self.assertIsInstance(team, list)
-        team = _run(self.user.get_team(gameweek=1))
-        self.assertIsInstance(team, list)
+    def test_active_chips(self):
+        active_chips = _run(self.user.get_active_chips())
+        self.assertIsInstance(active_chips, list)
+        self.assertEqual(len(active_chips), self.user.current_event)
 
-    def test_chip(self):
-        chip = _run(self.user.get_chips())
-        self.assertIsInstance(chip, list)
-        chip = _run(self.user.get_chips(gameweek=1))
-        self.assertEqual(chip, "")
+        active_chips = _run(self.user.get_active_chips(1))
+        self.assertIsInstance(active_chips, list)
 
     def test_automatic_substitutions(self):
         automatic_substitutions = _run(self.user.get_automatic_substitutions())
         self.assertIsInstance(automatic_substitutions, list)
+        self.assertEqual(len(automatic_substitutions),
+                         self.user.current_event)
+
         automatic_substitutions = _run(
-            self.user.get_automatic_substitutions(gameweek=1))
+            self.user.get_automatic_substitutions(1))
         self.assertIsInstance(automatic_substitutions, list)
 
-    def test_gameweek_history(self):
-        gameweek_history = _run(self.user.get_gameweek_history())
-        self.assertIsInstance(gameweek_history, list)
-        gameweek_history = _run(self.user.get_gameweek_history(gameweek=1))
-        self.assertIsInstance(gameweek_history, dict)
+    def test_team(self):
+        my_team = _run(self.user.get_team())
+        self.assertIsInstance(my_team, list)
 
     def test_transfers(self):
         transfers = _run(self.user.get_transfers())
-        self.assertIsInstance(transfers, dict)
+        self.assertIsInstance(transfers, list)
+
+        transfers = _run(self.user.get_transfers(1))
+        self.assertIsInstance(transfers, list)
 
     def test_wildcards(self):
         wildcards = _run(self.user.get_wildcards())
         self.assertIsInstance(wildcards, list)
-
-    def test_transfer_history(self):
-        transfer_history = _run(self.user.get_transfer_history())
-        self.assertIsInstance(transfer_history, list)
-        transfer_history = _run(self.user.get_transfer_history(gameweek=1))
-        self.assertIsInstance(transfer_history, list)
 
     def test_watchlist(self):
         watchlist = _run(self.user.get_watchlist())

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,78 +1,62 @@
-import unittest
+class TestUser(object):
+    async def test_gameweek_history(self, loop, user):
+        history = await user.get_gameweek_history()
+        assert isinstance(history, list)
 
-from fpl import FPL
-from fpl.utils import _run
+        history = await user.get_gameweek_history(1)
+        assert isinstance(history, dict)
 
+    async def test_season_history(self, loop, user):
+        season_history = await user.get_season_history()
+        assert isinstance(season_history, list)
 
-class UserTest(unittest.TestCase):
-    def setUp(self):
-        self.fpl = FPL()
-        _run(self.fpl.login())
-        self.user = _run(self.fpl.get_user("3808385"))
+    async def test_chips_history(self, loop, user):
+        chips = await user.get_chips_history()
+        assert isinstance(chips, list)
 
-    def test_gameweek_history(self):
-        history = _run(self.user.get_gameweek_history())
-        self.assertIsInstance(history, list)
+    async def test_leagues(self, loop, user):
+        leagues = user.leagues
+        assert isinstance(leagues, dict)
 
-        history = _run(self.user.get_gameweek_history(1))
-        self.assertIsInstance(history, dict)
+    async def test_picks(self, loop, user):
+        picks = await user.get_picks()
+        assert isinstance(picks, list)
+        assert len(picks) == user.current_event
 
-    def test_season_history(self):
-        season_history = _run(self.user.get_season_history())
-        self.assertIsInstance(season_history, list)
+        picks = await user.get_picks(1)
+        assert isinstance(picks, list)
 
-    def test_chips_history(self):
-        chips = _run(self.user.get_chips_history())
-        self.assertIsInstance(chips, list)
+    async def test_active_chips(self, loop, user):
+        active_chips = await user.get_active_chips()
+        assert isinstance(active_chips, list)
+        assert len(active_chips) == user.current_event
 
-    def test_leagues(self):
-        leagues = self.user.leagues
-        self.assertIsInstance(leagues, dict)
+        active_chips = await user.get_active_chips(1)
+        assert isinstance(active_chips, list)
 
-    def test_picks(self):
-        picks = _run(self.user.get_picks())
-        self.assertIsInstance(picks, list)
-        self.assertEqual(len(picks), self.user.current_event)
+    async def test_automatic_substitutions(self, loop, user):
+        automatic_substitutions = await user.get_automatic_substitutions()
+        assert isinstance(automatic_substitutions, list)
+        assert len(automatic_substitutions) == user.current_event
 
-        picks = _run(self.user.get_picks(1))
-        self.assertIsInstance(picks, list)
+        automatic_substitutions = await user.get_automatic_substitutions(1)
+        assert isinstance(automatic_substitutions, list)
 
-    def test_active_chips(self):
-        active_chips = _run(self.user.get_active_chips())
-        self.assertIsInstance(active_chips, list)
-        self.assertEqual(len(active_chips), self.user.current_event)
+    async def test_team(self, loop, user):
+        team = await user.get_team()
+        assert isinstance(team, list)
 
-        active_chips = _run(self.user.get_active_chips(1))
-        self.assertIsInstance(active_chips, list)
+    async def test_transfers(self, loop, user):
+        transfers = await user.get_transfers()
+        assert isinstance(transfers, list)
 
-    def test_automatic_substitutions(self):
-        automatic_substitutions = _run(self.user.get_automatic_substitutions())
-        self.assertIsInstance(automatic_substitutions, list)
-        self.assertEqual(len(automatic_substitutions),
-                         self.user.current_event)
+        transfers = await user.get_transfers(1)
+        assert isinstance(transfers, list)
 
-        automatic_substitutions = _run(
-            self.user.get_automatic_substitutions(1))
-        self.assertIsInstance(automatic_substitutions, list)
+    async def test_wildcards(self, loop, user):
+        wildcards = await user.get_wildcards()
+        assert isinstance(wildcards, list)
 
-    def test_team(self):
-        team = _run(self.user.get_team())
-        self.assertIsInstance(team, list)
-
-    def test_transfers(self):
-        transfers = _run(self.user.get_transfers())
-        self.assertIsInstance(transfers, list)
-
-        transfers = _run(self.user.get_transfers(1))
-        self.assertIsInstance(transfers, list)
-
-    def test_wildcards(self):
-        wildcards = _run(self.user.get_wildcards())
-        self.assertIsInstance(wildcards, list)
-
-    def test_watchlist(self):
-        watchlist = _run(self.user.get_watchlist())
-        self.assertIsInstance(watchlist, list)
-
-if __name__ == '__main__':
-    unittest.main()
+    async def test_watchlist(self, loop, user):
+        watchlist = await user.get_watchlist()
+        assert isinstance(watchlist, list)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,86 +1,89 @@
 import unittest
 
 from fpl import FPL
+from fpl.utils import _run
 
 
 class UserTest(unittest.TestCase):
     def setUp(self):
         self.fpl = FPL()
-        self.fpl.login()
-        self.user = self.fpl.get_user("3808385")
+        _run(self.fpl.login())
+        self.user = _run(self.fpl.get_user("3808385"))
 
     def test_history(self):
-        history = self.user.history
+        history = _run(self.user.get_history())
         self.assertIsInstance(history, dict)
 
     def test_season_history(self):
-        season_history = self.user.season_history
+        season_history = _run(self.user.get_season_history())
         self.assertIsInstance(season_history, list)
 
-    def test_chips(self):
-        chips = self.user.chips
+    def test_chips_history(self):
+        chips = _run(self.user.get_chips_history())
         self.assertIsInstance(chips, list)
 
     def test_leagues(self):
-        leagues = self.user.leagues
+        leagues = _run(self.user.get_leagues())
         self.assertIsInstance(leagues, dict)
 
     def test_classic(self):
-        classic = self.user.classic
+        classic = _run(self.user.get_classic_leagues())
         self.assertIsInstance(classic, list)
 
     def test_h2h(self):
-        h2h = self.user.h2h
+        h2h = _run(self.user.get_h2h_leagues())
         self.assertIsInstance(h2h, list)
 
     def test_picks(self):
-        picks = self.user.picks
-        self.assertIsInstance(picks, dict)
+        picks = _run(self.user.get_picks())
+        self.assertIsInstance(picks, list)
+        self.assertEqual(len(picks), self.user.current_gameweek)
 
     def test_my_team(self):
-        my_team = self.user.my_team()
+        my_team = _run(self.user.my_team())
         self.assertIsInstance(my_team, list)
 
     def test_team(self):
-        team = self.user.team()
+        team = _run(self.user.get_team())
         self.assertIsInstance(team, list)
-        team = self.user.team(gameweek=1)
+        team = _run(self.user.get_team(gameweek=1))
         self.assertIsInstance(team, list)
 
     def test_chip(self):
-        chip = self.user.chip()
+        chip = _run(self.user.get_chips())
         self.assertIsInstance(chip, list)
-        chip = self.user.chip(gameweek=1)
+        chip = _run(self.user.get_chips(gameweek=1))
         self.assertEqual(chip, "")
 
     def test_automatic_substitutions(self):
-        automatic_substitutions = self.user.automatic_substitutions()
+        automatic_substitutions = _run(self.user.get_automatic_substitutions())
         self.assertIsInstance(automatic_substitutions, list)
-        automatic_substitutions = self.user.automatic_substitutions(gameweek=1)
+        automatic_substitutions = _run(
+            self.user.get_automatic_substitutions(gameweek=1))
         self.assertIsInstance(automatic_substitutions, list)
 
     def test_gameweek_history(self):
-        gameweek_history = self.user.gameweek_history()
+        gameweek_history = _run(self.user.get_gameweek_history())
         self.assertIsInstance(gameweek_history, list)
-        gameweek_history = self.user.gameweek_history(gameweek=1)
+        gameweek_history = _run(self.user.get_gameweek_history(gameweek=1))
         self.assertIsInstance(gameweek_history, dict)
 
     def test_transfers(self):
-        transfers = self.user.transfers
+        transfers = _run(self.user.get_transfers())
         self.assertIsInstance(transfers, dict)
 
     def test_wildcards(self):
-        wildcards = self.user.wildcards
+        wildcards = _run(self.user.get_wildcards())
         self.assertIsInstance(wildcards, list)
 
     def test_transfer_history(self):
-        transfer_history = self.user.transfer_history()
+        transfer_history = _run(self.user.get_transfer_history())
         self.assertIsInstance(transfer_history, list)
-        transfer_history = self.user.transfer_history(gameweek=1)
+        transfer_history = _run(self.user.get_transfer_history(gameweek=1))
         self.assertIsInstance(transfer_history, list)
 
     def test_watchlist(self):
-        watchlist = self.user.watchlist
+        watchlist = _run(self.user.get_watchlist())
         self.assertIsInstance(watchlist, list)
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Use `aiohttp` instead of `requests` for asynchronous HTTP requests
* Add kwarg `return_json` to return `dict` instead of object
* Refactor all functions and classes
* Class properties are now the same as the FPL API (e.g. instead of `user.name` it would be `user.player_first_name`) to keep a consistency between `dict` and objects
* Convert tests to use `pytest-aiohttp` for async support
