### PR TITLE
Update tests so that they don't rely on specific credentials

### DIFF
--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -133,6 +133,7 @@ class FPL():
             19 - West Ham
             20 - Wolves
         """
+        assert 0 < team_id < 21, "Team ID must be in [1, 20]."
         url = API_URLS["teams"]
         teams = await fetch(self.session, url)
         team = next(team for team in teams if team["id"] == int(team_id))

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -133,7 +133,7 @@ class FPL():
             19 - West Ham
             20 - Wolves
         """
-        assert 0 < team_id < 21, "Team ID must be in [1, 20]."
+        assert 0 < int(team_id) < 21, "Team ID must be a number between 1 and 20."
         url = API_URLS["teams"]
         teams = await fetch(self.session, url)
         team = next(team for team in teams if team["id"] == int(team_id))

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -156,6 +156,7 @@ class FPL():
         :type return_json: bool
         :rtype: :class:`PlayerSummary` or ``dict``
         """
+        assert int(player_id) > 0, "Player's ID must be a positive number"
         url = API_URLS["player"].format(player_id)
         player_summary = await fetch(self.session, url)
 

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -67,7 +67,7 @@ class FPL():
             return user
         return User(user, session=self.session)
 
-    async def get_teams(self, team_ids=[], return_json=False):
+    async def get_teams(self, team_ids=None, return_json=False):
         """Returns either a list of *all* teams, or a list of teams with IDs in
         the optional ``team_ids`` list.
 
@@ -86,6 +86,7 @@ class FPL():
         teams = await fetch(self.session, url)
 
         if team_ids:
+            team_ids = set(team_ids)
             teams = [team for team in teams if team["id"] in team_ids]
 
         if return_json:

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -232,7 +232,7 @@ class FPL():
 
         return Player(player)
 
-    async def get_players(self, player_ids=[], include_summary=False,
+    async def get_players(self, player_ids=None, include_summary=False,
                           return_json=False):
         """Returns either a list of *all* players, or a list of players whose
         IDs are in the given ``player_ids`` list.

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -316,6 +316,9 @@ class FPL():
         :type return_json: bool
         :rtype: list
         """
+        if not fixture_ids:
+            return []
+
         fixtures = await fetch(self.session, API_URLS["fixtures"])
         fixture_gameweeks = set(fixture["event"] for fixture in fixtures
                                 if fixture["id"] in fixture_ids)

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -407,8 +407,11 @@ class FPL():
         """
 
         static_gameweeks = await fetch(self.session, API_URLS["gameweeks"])
-        static_gameweek = next(gameweek for gameweek in static_gameweeks if
-                               gameweek["id"] == gameweek_id)
+        try:
+            static_gameweek = next(gameweek for gameweek in static_gameweeks if
+                                   gameweek["id"] == gameweek_id)
+        except StopIteration:
+            raise ValueError(f"Gameweek with ID {gameweek_id} not found")
         live_gameweek = await fetch(
             self.session, API_URLS["gameweek_live"].format(gameweek_id))
 

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -59,6 +59,7 @@ class FPL():
         :type return_json: bool
         :rtype: :class:`User` or `dict`
         """
+        assert int(user_id) > 0, "User ID must be a positive number."
         url = API_URLS["user"].format(user_id)
         user = await fetch(self.session, url)
 

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -165,20 +165,23 @@ class FPL():
 
         return PlayerSummary(player_summary)
 
-    async def get_player_summaries(self, player_ids=[], return_json=False):
-        """Returns either a list of summaries of *all* players, or a list of
-        summaries of players whose ID are in the ``player_ids`` list.
+    async def get_player_summaries(self, player_ids, return_json=False):
+        """Returns a list of summaries of players whose ID are
+        in the ``player_ids`` list.
 
         Information is taken from e.g.:
             https://fantasy.premierleague.com/drf/element-summary/1
 
-        :param list player_ids: (optional) A list of player IDs.
+        :param list player_ids: A list of player IDs.
         :param return_json: (optional) Boolean. If ``True`` returns a list of
             ``dict``s, if ``False`` returns a list of  :class:`PlayerSummary`
             objects. Defaults to ``False``.
         :type return_json: bool
         :rtype: list
         """
+        if not player_ids:
+            return []
+
         tasks = [asyncio.ensure_future(
                  fetch(self.session, API_URLS["player"].format(player_id)))
                  for player_id in player_ids]

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -211,12 +211,16 @@ class FPL():
             if ``False`` returns a :class:`Player` object. Defaults to
             ``False``.
         :rtype: :class:`Player` or ``dict``
+        :raises ValueError: Player with ``player_id`` not found
         """
         if not players:
             players = await fetch(self.session, API_URLS["players"])
 
-        player = next(player for player in players
-                      if player["id"] == player_id)
+        try:
+            player = next(player for player in players
+                          if player["id"] == player_id)
+        except StopIteration:
+            raise ValueError(f"Player with ID {player_id} not found")
 
         if include_summary:
             player_summary = await self.get_player_summary(

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -504,14 +504,16 @@ class FPL():
     async def login(self, email=None, password=None):
         """Returns a requests session with FPL login authentication.
 
-        :param string user: Email address for the user's Fantasy Premier League
+        :param string email: Email address for the user's Fantasy Premier League
             account.
         :param string password: Password for the user's Fantasy Premier League
             account.
         """
         if not email and not password:
-            email = os.environ["FPL_EMAIL"]
-            password = os.environ["FPL_PASSWORD"]
+            email = os.getenv("FPL_EMAIL", None)
+            password = os.getenv("FPL_PASSWORD", None)
+        if not email or not password:
+            raise ValueError("Email and password must be set")
 
         url = "https://fantasy.premierleague.com/"
         await self.session.get(url)

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -275,19 +275,26 @@ class FPL():
             ``False``.
         :type return_json: bool
         :rtype: :class:`Fixture` or ``dict``
+        :raises ValueError: if fixture with ``fixture_id`` not found
         """
         fixtures = await fetch(self.session, API_URLS["fixtures"])
 
-        fixture = next(fixture for fixture in fixtures
-                       if fixture["id"] == fixture_id)
+        try:
+            fixture = next(fixture for fixture in fixtures
+                           if fixture["id"] == fixture_id)
+        except StopIteration:
+            raise ValueError(f"Fixture with ID {fixture_id} not found")
         fixture_gameweek = fixture["event"]
 
         gameweek_fixtures = await fetch(
             self.session,
             API_URLS["gameweek_fixtures"].format(fixture_gameweek))
 
-        fixture = next(fixture for fixture in gameweek_fixtures
-                       if fixture["id"] == fixture_id)
+        try:
+            fixture = next(fixture for fixture in gameweek_fixtures
+                           if fixture["id"] == fixture_id)
+        except StopIteration:
+            raise ValueError(f"Fixture with ID {fixture_id} not found in gameweek fixtures")
 
         if return_json:
             return fixture

--- a/fpl/models/fixture.py
+++ b/fpl/models/fixture.py
@@ -35,19 +35,20 @@ class Fixture():
         """Helper function that returns a dictionary containing players for the
         given metric (away and home).
         """
-        for statistic in self.stats:
+        stats = getattr(self, "stats", [])
+        for statistic in stats:
             if metric in statistic.keys():
-                player_information = statistic[metric]
+                return statistic[metric]
 
-        return player_information
+        return {}
 
     def get_goalscorers(self):
         """Returns all players who scored in the fixture.
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("goals_scored")
 
@@ -56,8 +57,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("assists")
 
@@ -66,8 +67,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("own_goals")
 
@@ -76,8 +77,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("yellow_cards")
 
@@ -86,8 +87,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("red_cards")
 
@@ -96,8 +97,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("penalties_saved")
 
@@ -106,8 +107,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("penalties_missed")
 
@@ -116,8 +117,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("saves")
 
@@ -126,8 +127,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("bonus")
 
@@ -136,8 +137,8 @@ class Fixture():
 
         :rtype: dict
         """
-        if not self.finished:
-            return
+        if not getattr(self, "finished", False):
+            return {}
 
         return self._get_players("bps")
 

--- a/fpl/models/h2h_league.py
+++ b/fpl/models/h2h_league.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from ..constants import API_URLS
-from ..utils import fetch, get_current_gameweek
+from ..utils import fetch, get_current_gameweek, logged_in
 
 
 class H2HLeague():
@@ -23,7 +23,7 @@ class H2HLeague():
       >>> asyncio.run(main())
       League 760869 - 760869
     """
-    def __init__(self, league_information, session=None):
+    def __init__(self, league_information, session):
         self._session = session
 
         for k, v in league_information.items():
@@ -41,6 +41,9 @@ class H2HLeague():
         """
         if not self._session:
             return
+
+        if not logged_in(self._session):
+            raise Exception("Not authorized to get h2h fixtures. Log in.")
 
         if gameweek:
             gameweeks = range(gameweek, gameweek + 1)

--- a/fpl/models/player.py
+++ b/fpl/models/player.py
@@ -30,7 +30,7 @@ class Player():
 
         :rtype: int
         """
-        return sum([1 for fixture in self.fixtures if fixture["minutes"] > 0])
+        return sum([1 for fixture in getattr(self, "fixtures", []) if fixture["minutes"] > 0])
 
     @property
     def pp90(self):
@@ -38,9 +38,10 @@ class Player():
 
         :rtype: float
         """
-        if self.minutes == 0:
+        minutes = getattr(self, "minutes", 0)
+        if minutes == 0:
             return 0
-        return self.total_points / float(self.minutes)
+        return getattr(self, "total_points", 0) / float(minutes)
 
     def __str__(self):
         return (f"{self.web_name} - "

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -181,7 +181,7 @@ class User():
             return next(pick["automatic_subs"] for pick in picks
                         if pick["event"]["id"] == gameweek)
 
-        return [pick["automatic_subs"] for pick in picks]
+        return [p for pick in picks for p in pick["automatic_subs"]]
 
     async def get_team(self):
         """Returns a logged in user's current team. Requires the user to have

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -213,13 +213,11 @@ class User():
         :param gameweek: (optional): The gameweek. Defaults to ``None``.
         :rtype: list
         """
-        if hasattr(self, "_transfers"):
-            return self._transfers["history"]
-
-        transfers = await fetch(
-            self._session, API_URLS["user_transfers"].format(self.id))
-
-        self._transfers = transfers
+        transfers = getattr(self, "_transfers", None)
+        if not transfers:
+            transfers = await fetch(
+                self._session, API_URLS["user_transfers"].format(self.id))
+            self._transfers = transfers
 
         if gameweek:
             valid_gameweek(gameweek)

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -9,9 +9,11 @@ def valid_gameweek(gameweek):
 
     :param gameweek: The gameweek.
     :type gameweek: int or string
+    :raises ValueError: if gameweek is not a number in [1, 38]
     """
-    if not isinstance(gameweek, int) and (gameweek < 1 or gameweek > 38):
-        raise "Gameweek must be a number between 1 and 38."
+    gameweek = int(gameweek)
+    if (gameweek < 1) or (gameweek > 38):
+        raise ValueError("Gameweek must be a number between 1 and 38.")
     return True
 
 

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -72,7 +72,7 @@ class User():
         :rtype: list
         """
         if hasattr(self, "_history"):
-            history = self._history["season"]
+            history = self._history
         else:
             history = await fetch(
                 self._session, API_URLS["user_history"].format(self.id))

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -128,7 +128,7 @@ class User():
             return next(pick["picks"] for pick in picks
                         if pick["event"]["id"] == gameweek)
 
-        return [pick["picks"] for pick in picks]
+        return [p for pick in picks for p in pick["picks"]]
 
     async def get_active_chips(self, gameweek=None):
         """Returns a list containing the user's active chips each gameweek.

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -9,7 +9,7 @@ def valid_gameweek(gameweek):
 
     :param gameweek: The gameweek.
     :type gameweek: int or string
-    :raises ValueError: if gameweek is not a number in [1, 38]
+    :raises ValueError: if gameweek is not a number between 1 and 38
     """
     gameweek = int(gameweek)
     if (gameweek < 1) or (gameweek > 38):

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -1,7 +1,7 @@
 import asyncio
 
 from ..constants import API_URLS
-from ..utils import fetch
+from ..utils import fetch, logged_in
 
 
 def valid_gameweek(gameweek):
@@ -192,8 +192,8 @@ class User():
 
         :rtype: list
         """
-        if not self._session:
-            raise "User must be logged in."
+        if not logged_in(self._session):
+            raise Exception("User must be logged in.")
 
         response = await fetch(
             self._session, API_URLS["user_team"].format(self.id))
@@ -255,8 +255,8 @@ class User():
 
         :rtype: list
         """
-        if not self._session:
-            raise "User must be logged in."
+        if not logged_in(self._session):
+            raise Exception("User must be logged in.")
 
         return await fetch(self._session, API_URLS["watchlist"])
 

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -85,3 +85,14 @@ def scale(value, upper, lower, min_, max_):
 def average(iterable):
     """Returns the average value of the iterable."""
     return sum(iterable) / float(len(iterable))
+
+
+def logged_in(session):
+    """Checks that the user is logged in within the session.
+
+    :param session: http session
+    :type session: aiohttp.ClientSession
+    :return: True if user is logged in else False
+    :rtype: bool
+    """
+    return "csrftoken" in session.cookie_jar.filter_cookies("https://users.premierleague.com/")

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "appdirs",
         "aiohttp",
         "pytest-aiohttp",
+        "pytest-mock",
         "pytest",
     ],
     entry_points="""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,11 +57,3 @@ async def team():
     await session.close()
 
 
-@pytest.fixture()
-async def user():
-    session = aiohttp.ClientSession()
-    fpl = FPL(session)
-    await fpl.login()
-    user = await fpl.get_user(3808385)
-    yield user
-    await session.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,10 @@ import aiohttp
 import pytest
 
 from fpl import FPL
+from fpl.models import Fixture, H2HLeague, User
+from tests.test_fixture import fixture_data
+from tests.test_h2h_league import h2h_league_data
+from tests.test_user import user_data
 
 
 @pytest.fixture()
@@ -57,3 +61,20 @@ async def team():
     await session.close()
 
 
+@pytest.fixture()
+def fixture():
+    return Fixture(fixture_data)
+
+
+@pytest.fixture()
+async def h2h_league():
+    session = aiohttp.ClientSession()
+    yield H2HLeague(h2h_league_data, session)
+    await session.close()
+
+
+@pytest.fixture()
+async def user():
+    session = aiohttp.ClientSession()
+    yield User(user_data, session)
+    await session.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,16 +130,6 @@ async def gameweek():
 
 
 @pytest.fixture()
-async def h2h_league():
-    session = aiohttp.ClientSession()
-    fpl = FPL(session)
-    await fpl.login()
-    h2h_league = await fpl.get_h2h_league(760869)
-    yield h2h_league
-    await session.close()
-
-
-@pytest.fixture()
 async def player():
     session = aiohttp.ClientSession()
     fpl = FPL(session)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import aiohttp
 import pytest
 
 from fpl import FPL
-from fpl.models.fixture import Fixture
 
 
 @pytest.fixture()
@@ -20,104 +19,6 @@ async def classic_league():
     classic_league = await fpl.get_classic_league(633353)
     yield classic_league
     await session.close()
-
-
-@pytest.fixture()
-def fixture():
-    fixture = {
-        "id": 6,
-        "kickoff_time_formatted": "10 Aug 20:00",
-        "started": True,
-        "event_day": 1,
-        "deadline_time": "2018-08-10T18:00:00Z",
-        "deadline_time_formatted": "10 Aug 19:00",
-        "stats": [
-            {
-                "goals_scored": {
-                    "a": [{"value": 1, "element": 234}],
-                    "h": [{"value": 1, "element": 286}, {"value": 1, "element": 302}],
-                }
-            },
-            {
-                "assists": {
-                    "a": [{"value": 1, "element": 221}],
-                    "h": [{"value": 1, "element": 295}, {"value": 1, "element": 297}],
-                }
-            },
-            {"own_goals": {"a": [], "h": []}},
-            {"penalties_saved": {"a": [], "h": []}},
-            {"penalties_missed": {"a": [], "h": []}},
-            {
-                "yellow_cards": {
-                    "a": [{"value": 1, "element": 226}],
-                    "h": [{"value": 1, "element": 304}, {"value": 1, "element": 481}],
-                }
-            },
-            {"red_cards": {"a": [], "h": []}},
-            {
-                "saves": {
-                    "a": [{"value": 4, "element": 213}],
-                    "h": [{"value": 3, "element": 282}],
-                }
-            },
-            {
-                "bonus": {
-                    "a": [{"value": 1, "element": 234}],
-                    "h": [{"value": 3, "element": 286}, {"value": 2, "element": 302}],
-                }
-            },
-            {
-                "bps": {
-                    "a": [
-                        {"value": 25, "element": 234},
-                        {"value": 23, "element": 221},
-                        {"value": 16, "element": 213},
-                        {"value": 16, "element": 215},
-                        {"value": 15, "element": 225},
-                        {"value": 14, "element": 220},
-                        {"value": 13, "element": 227},
-                        {"value": 13, "element": 231},
-                        {"value": 12, "element": 219},
-                        {"value": 10, "element": 233},
-                        {"value": 6, "element": 226},
-                        {"value": 5, "element": 228},
-                        {"value": 3, "element": 492},
-                        {"value": 2, "element": 236},
-                    ],
-                    "h": [
-                        {"value": 30, "element": 286},
-                        {"value": 29, "element": 302},
-                        {"value": 24, "element": 297},
-                        {"value": 22, "element": 295},
-                        {"value": 16, "element": 289},
-                        {"value": 15, "element": 282},
-                        {"value": 15, "element": 292},
-                        {"value": 13, "element": 291},
-                        {"value": 13, "element": 305},
-                        {"value": 13, "element": 481},
-                        {"value": 8, "element": 304},
-                        {"value": 4, "element": 298},
-                        {"value": 3, "element": 303},
-                        {"value": -2, "element": 306},
-                    ],
-                }
-            },
-        ],
-        "team_h_difficulty": 3,
-        "team_a_difficulty": 4,
-        "code": 987597,
-        "kickoff_time": "2018-08-10T19:00:00Z",
-        "team_h_score": 2,
-        "team_a_score": 1,
-        "finished": True,
-        "minutes": 90,
-        "provisional_start_time": False,
-        "finished_provisional": True,
-        "event": 1,
-        "team_a": 11,
-        "team_h": 14,
-    }
-    return Fixture(fixture)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import aiohttp
 import pytest
 
 from fpl import FPL
+from fpl.models.fixture import Fixture
 
 
 @pytest.fixture()
@@ -22,12 +23,101 @@ async def classic_league():
 
 
 @pytest.fixture()
-async def fixture():
-    session = aiohttp.ClientSession()
-    fpl = FPL(session)
-    fixture = await fpl.get_fixture(6)
-    yield fixture
-    await session.close()
+def fixture():
+    fixture = {
+        "id": 6,
+        "kickoff_time_formatted": "10 Aug 20:00",
+        "started": True,
+        "event_day": 1,
+        "deadline_time": "2018-08-10T18:00:00Z",
+        "deadline_time_formatted": "10 Aug 19:00",
+        "stats": [
+            {
+                "goals_scored": {
+                    "a": [{"value": 1, "element": 234}],
+                    "h": [{"value": 1, "element": 286}, {"value": 1, "element": 302}],
+                }
+            },
+            {
+                "assists": {
+                    "a": [{"value": 1, "element": 221}],
+                    "h": [{"value": 1, "element": 295}, {"value": 1, "element": 297}],
+                }
+            },
+            {"own_goals": {"a": [], "h": []}},
+            {"penalties_saved": {"a": [], "h": []}},
+            {"penalties_missed": {"a": [], "h": []}},
+            {
+                "yellow_cards": {
+                    "a": [{"value": 1, "element": 226}],
+                    "h": [{"value": 1, "element": 304}, {"value": 1, "element": 481}],
+                }
+            },
+            {"red_cards": {"a": [], "h": []}},
+            {
+                "saves": {
+                    "a": [{"value": 4, "element": 213}],
+                    "h": [{"value": 3, "element": 282}],
+                }
+            },
+            {
+                "bonus": {
+                    "a": [{"value": 1, "element": 234}],
+                    "h": [{"value": 3, "element": 286}, {"value": 2, "element": 302}],
+                }
+            },
+            {
+                "bps": {
+                    "a": [
+                        {"value": 25, "element": 234},
+                        {"value": 23, "element": 221},
+                        {"value": 16, "element": 213},
+                        {"value": 16, "element": 215},
+                        {"value": 15, "element": 225},
+                        {"value": 14, "element": 220},
+                        {"value": 13, "element": 227},
+                        {"value": 13, "element": 231},
+                        {"value": 12, "element": 219},
+                        {"value": 10, "element": 233},
+                        {"value": 6, "element": 226},
+                        {"value": 5, "element": 228},
+                        {"value": 3, "element": 492},
+                        {"value": 2, "element": 236},
+                    ],
+                    "h": [
+                        {"value": 30, "element": 286},
+                        {"value": 29, "element": 302},
+                        {"value": 24, "element": 297},
+                        {"value": 22, "element": 295},
+                        {"value": 16, "element": 289},
+                        {"value": 15, "element": 282},
+                        {"value": 15, "element": 292},
+                        {"value": 13, "element": 291},
+                        {"value": 13, "element": 305},
+                        {"value": 13, "element": 481},
+                        {"value": 8, "element": 304},
+                        {"value": 4, "element": 298},
+                        {"value": 3, "element": 303},
+                        {"value": -2, "element": 306},
+                    ],
+                }
+            },
+        ],
+        "team_h_difficulty": 3,
+        "team_a_difficulty": 4,
+        "code": 987597,
+        "kickoff_time": "2018-08-10T19:00:00Z",
+        "team_h_score": 2,
+        "team_a_score": 1,
+        "finished": True,
+        "minutes": 90,
+        "provisional_start_time": False,
+        "finished_provisional": True,
+        "event": 1,
+        "team_a": 11,
+        "team_h": 14,
+    }
+    return Fixture(fixture)
 
 
 @pytest.fixture()

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,0 +1,6 @@
+from unittest.mock import MagicMock
+
+
+class AsyncMock(MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super(AsyncMock, self).__call__(*args, **kwargs)

--- a/tests/test_classic_league.py
+++ b/tests/test_classic_league.py
@@ -1,4 +1,28 @@
+import aiohttp
+
+from fpl.models.classic_league import ClassicLeague
+
+
 class TestClassicLeague(object):
+    async def test_init(self, loop):
+        data = {
+            "new_entries": {"has_next": False, "number": 1, "results": []},
+            "league": {
+                "id": 1,
+                "leagueban_set": [],
+                "name": "Arsenal",
+                "short_name": "team-1",
+                "created": "2018-07-05T12:12:23Z",
+                "closed": False,
+            },
+        }
+        session = aiohttp.ClientSession()
+        classic_league = ClassicLeague(data, session)
+        assert classic_league._session is session
+        for k, v in data.items():
+            assert getattr(classic_league, k) == v
+        await session.close()
+
     async def test_classic_league(self, loop, classic_league):
         assert classic_league.__str__() == "Steem Fantasy League - 633353"
 

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,5 +1,3 @@
-import pytest
-
 from fpl.models.fixture import Fixture
 
 fixture_data = {
@@ -95,11 +93,6 @@ fixture_data = {
     "team_a": 11,
     "team_h": 14,
 }
-
-
-@pytest.fixture()
-def fixture():
-    return Fixture(fixture_data)
 
 
 class TestFixture(object):

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,40 +1,106 @@
+from fpl.models.fixture import Fixture
+
+
 class TestFixture(object):
-    def test_get_goalscorers(self, loop, fixture):
-        goalscorers = fixture.get_goalscorers()
-        assert isinstance(goalscorers, dict)
+    def test_init(self):
+        data = {
+            "id": 265,
+            "kickoff_time_formatted": None,
+            "started": False,
+            "event_day": None,
+            "deadline_time": None,
+            "deadline_time_formatted": None,
+            "stats": [],
+            "team_h_difficulty": 2,
+            "team_a_difficulty": 4,
+            "code": 987856,
+            "kickoff_time": None,
+            "team_h_score": None,
+            "team_a_score": None,
+            "finished": False,
+            "minutes": 0,
+            "provisional_start_time": False,
+            "finished_provisional": False,
+            "event": None,
+            "team_a": 3,
+            "team_h": 6,
+        }
+        fixture = Fixture(data)
+        for k, v in data.items():
+            assert getattr(fixture, k) == v
 
-    def test_get_assisters(self, loop, fixture):
-        assisters = fixture.get_assisters()
-        assert isinstance(assisters, dict)
+    @staticmethod
+    def _do_test_not_finished(fixture, method):
+        delattr(fixture, "finished")
+        data_dict = getattr(fixture, method)()
+        assert isinstance(data_dict, dict)
+        assert len(data_dict) == 0
 
-    def test_get_own_goalscorers(self, loop, fixture):
-        own_goalscorers = fixture.get_own_goalscorers()
-        assert isinstance(own_goalscorers, dict)
+    @staticmethod
+    def _do_test_finished(fixture, method):
+        data_dict = getattr(fixture, method)()
+        assert isinstance(data_dict, dict)
+        assert len(data_dict) == 2
 
-    def test_get_yellow_cards(self, loop, fixture):
-        yellow_cards = fixture.get_yellow_cards()
-        assert isinstance(yellow_cards, dict)
+    def test_get_goalscorers_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_goalscorers")
 
-    def test_get_red_cards(self, loop, fixture):
-        red_cards = fixture.get_red_cards()
-        assert isinstance(red_cards, dict)
+    def test_get_goalscorers_finished(self, fixture):
+        self._do_test_finished(fixture, "get_goalscorers")
 
-    def test_get_penalty_saves(self, loop, fixture):
-        penalty_saves = fixture.get_penalty_saves()
-        assert isinstance(penalty_saves, dict)
+    def test_get_assisters_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_assisters")
 
-    def test_get_penalty_misses(self, loop, fixture):
-        penalty_misses = fixture.get_penalty_misses()
-        assert isinstance(penalty_misses, dict)
+    def test_get_assisters_finished(self, fixture):
+        self._do_test_finished(fixture, "get_assisters")
 
-    def test_get_saves(self, loop, fixture):
-        saves = fixture.get_saves()
-        assert isinstance(saves, dict)
+    def test_get_own_goalscorers_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_own_goalscorers")
 
-    def test_get_bonus(self, loop, fixture):
-        bonus = fixture.get_bonus()
-        assert isinstance(bonus, dict)
+    def test_get_own_goalscorers_finished(self, fixture):
+        self._do_test_finished(fixture, "get_own_goalscorers")
 
-    def test_get_bps(self, loop, fixture):
-        bps = fixture.get_bps()
-        assert isinstance(bps, dict)
+    def test_get_yellow_cards_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_yellow_cards")
+
+    def test_get_yellow_cards(self, fixture):
+        self._do_test_finished(fixture, "get_yellow_cards")
+
+    def test_get_red_cards_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_red_cards")
+
+    def test_get_red_cards_finished(self, fixture):
+        self._do_test_finished(fixture, "get_red_cards")
+
+    def test_get_penalty_saves_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_penalty_saves")
+
+    def test_get_penalty_saves_finished(self, fixture):
+        self._do_test_finished(fixture, "get_penalty_saves")
+
+    def test_get_penalty_misses_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_penalty_misses")
+
+    def test_get_penalty_misses_finished(self, fixture):
+        self._do_test_finished(fixture, "get_penalty_misses")
+
+    def test_get_saves_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_saves")
+
+    def test_get_saves_finished(self, fixture):
+        self._do_test_finished(fixture, "get_saves")
+
+    def test_get_bonus_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_bonus")
+
+    def test_get_bonus_finished(self, fixture):
+        self._do_test_finished(fixture, "get_bonus")
+
+    def test_get_bps_not_finished(self, fixture):
+        self._do_test_not_finished(fixture, "get_bps")
+
+    def test_get_bps_finished(self, fixture):
+        self._do_test_finished(fixture, "get_bps")
+
+    def test_str(self, fixture):
+        assert str(fixture) == "Man Utd vs. Leicester - 10 Aug 19:00"

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,32 +1,111 @@
+import pytest
+
 from fpl.models.fixture import Fixture
+
+fixture_data = {
+    "id": 6,
+    "kickoff_time_formatted": "10 Aug 20:00",
+    "started": True,
+    "event_day": 1,
+    "deadline_time": "2018-08-10T18:00:00Z",
+    "deadline_time_formatted": "10 Aug 19:00",
+    "stats": [
+        {
+            "goals_scored": {
+                "a": [{"value": 1, "element": 234}],
+                "h": [{"value": 1, "element": 286}, {"value": 1, "element": 302}],
+            }
+        },
+        {
+            "assists": {
+                "a": [{"value": 1, "element": 221}],
+                "h": [{"value": 1, "element": 295}, {"value": 1, "element": 297}],
+            }
+        },
+        {"own_goals": {"a": [], "h": []}},
+        {"penalties_saved": {"a": [], "h": []}},
+        {"penalties_missed": {"a": [], "h": []}},
+        {
+            "yellow_cards": {
+                "a": [{"value": 1, "element": 226}],
+                "h": [{"value": 1, "element": 304}, {"value": 1, "element": 481}],
+            }
+        },
+        {"red_cards": {"a": [], "h": []}},
+        {
+            "saves": {
+                "a": [{"value": 4, "element": 213}],
+                "h": [{"value": 3, "element": 282}],
+            }
+        },
+        {
+            "bonus": {
+                "a": [{"value": 1, "element": 234}],
+                "h": [{"value": 3, "element": 286}, {"value": 2, "element": 302}],
+            }
+        },
+        {
+            "bps": {
+                "a": [
+                    {"value": 25, "element": 234},
+                    {"value": 23, "element": 221},
+                    {"value": 16, "element": 213},
+                    {"value": 16, "element": 215},
+                    {"value": 15, "element": 225},
+                    {"value": 14, "element": 220},
+                    {"value": 13, "element": 227},
+                    {"value": 13, "element": 231},
+                    {"value": 12, "element": 219},
+                    {"value": 10, "element": 233},
+                    {"value": 6, "element": 226},
+                    {"value": 5, "element": 228},
+                    {"value": 3, "element": 492},
+                    {"value": 2, "element": 236},
+                ],
+                "h": [
+                    {"value": 30, "element": 286},
+                    {"value": 29, "element": 302},
+                    {"value": 24, "element": 297},
+                    {"value": 22, "element": 295},
+                    {"value": 16, "element": 289},
+                    {"value": 15, "element": 282},
+                    {"value": 15, "element": 292},
+                    {"value": 13, "element": 291},
+                    {"value": 13, "element": 305},
+                    {"value": 13, "element": 481},
+                    {"value": 8, "element": 304},
+                    {"value": 4, "element": 298},
+                    {"value": 3, "element": 303},
+                    {"value": -2, "element": 306},
+                ],
+            }
+        },
+    ],
+    "team_h_difficulty": 3,
+    "team_a_difficulty": 4,
+    "code": 987597,
+    "kickoff_time": "2018-08-10T19:00:00Z",
+    "team_h_score": 2,
+    "team_a_score": 1,
+    "finished": True,
+    "minutes": 90,
+    "provisional_start_time": False,
+    "finished_provisional": True,
+    "event": 1,
+    "team_a": 11,
+    "team_h": 14,
+}
+
+
+@pytest.fixture()
+def fixture():
+    return Fixture(fixture_data)
 
 
 class TestFixture(object):
     def test_init(self):
-        data = {
-            "id": 265,
-            "kickoff_time_formatted": None,
-            "started": False,
-            "event_day": None,
-            "deadline_time": None,
-            "deadline_time_formatted": None,
-            "stats": [],
-            "team_h_difficulty": 2,
-            "team_a_difficulty": 4,
-            "code": 987856,
-            "kickoff_time": None,
-            "team_h_score": None,
-            "team_a_score": None,
-            "finished": False,
-            "minutes": 0,
-            "provisional_start_time": False,
-            "finished_provisional": False,
-            "event": None,
-            "team_a": 3,
-            "team_h": 6,
-        }
-        fixture = Fixture(data)
-        for k, v in data.items():
+        fixture = Fixture(fixture_data)
+        for k, v in fixture_data.items():
             assert getattr(fixture, k) == v
 
     @staticmethod

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 import aiohttp
 import pytest
 
@@ -11,11 +9,7 @@ from fpl.models.h2h_league import H2HLeague
 from fpl.models.player import Player, PlayerSummary
 from fpl.models.team import Team
 from fpl.models.user import User
-
-
-class AsyncMock(MagicMock):
-    async def __call__(self, *args, **kwargs):
-        return super(AsyncMock, self).__call__(*args, **kwargs)
+from tests.helper import AsyncMock
 
 
 class TestFPL(object):

--- a/tests/test_h2h_league.py
+++ b/tests/test_h2h_league.py
@@ -31,13 +31,6 @@ h2h_league_data = {
 }
 
 
-@pytest.fixture()
-async def h2h_league():
-    session = aiohttp.ClientSession()
-    yield H2HLeague(h2h_league_data, session)
-    await session.close()
-
-
 class TestH2HLeague(object):
     async def test_init(self, loop):
         session = aiohttp.ClientSession()

--- a/tests/test_h2h_league.py
+++ b/tests/test_h2h_league.py
@@ -1,8 +1,91 @@
-class TestH2HLeague(object):
-    def test_h2h_league(self, loop, h2h_league):
-        assert h2h_league.__str__() == "League 760869 - 760869"
+import aiohttp
+import pytest
 
-    async def test_fixtures(self, loop, h2h_league):
+from fpl.models.h2h_league import H2HLeague
+from tests.helper import AsyncMock
+
+h2h_league_data = {
+    "new_entries": {"has_next": False, "number": 1, "results": []},
+    "league": {
+        "id": 829116,
+        "leagueban_set": [],
+        "name": "League 829116",
+        "has_started": True,
+        "can_delete": False,
+        "short_name": None,
+        "created": "2018-08-09T18:10:37Z",
+        "closed": True,
+        "forum_disabled": False,
+        "make_code_public": False,
+        "rank": None,
+        "size": None,
+        "league_type": "c",
+        "_scoring": "h",
+        "ko_rounds": 2,
+        "admin_entry": None,
+        "start_event": 1,
+    },
+    "standings": {"has_next": False, "number": 1, "results": []},
+    "matches_next": {},
+    "matches_this": {},
+}
+
+
+@pytest.fixture()
+async def h2h_league():
+    session = aiohttp.ClientSession()
+    yield H2HLeague(h2h_league_data, session)
+    await session.close()
+
+
+class TestH2HLeague(object):
+    async def test_init(self, loop):
+        session = aiohttp.ClientSession()
+        league = H2HLeague(h2h_league_data, session)
+        assert league._session == session
+        for k, v in h2h_league_data.items():
+            assert getattr(league, k) == v
+        await session.close()
+
+    def test_h2h_league(self, loop, h2h_league):
+        assert h2h_league.__str__() == "League 829116 - 829116"
+
+    async def test_get_fixtures_with_known_gameweek_unauthorized(
+        self, loop, h2h_league):
+        with pytest.raises(Exception):
+            await h2h_league.get_fixtures(1)
+
+    async def test_get_fixtures_with_known_gameweek_authorized(
+        self, loop, mocker, h2h_league):
+        mocked_logged_in = mocker.patch(
+            "fpl.models.h2h_league.logged_in", return_value=True)
+        mocked_fetch = mocker.patch(
+            "fpl.models.h2h_league.fetch", return_value={}, new_callable=AsyncMock)
+        fixtures = await h2h_league.get_fixtures(1)
+        assert isinstance(fixtures, list)
+        assert len(fixtures) == 1
+        mocked_logged_in.assert_called_once()
+        mocked_fetch.assert_called_once()
+
+    async def test_get_fixtures_with_unknown_gameweek_unauthorized(
+        self, loop, h2h_league):
+        with pytest.raises(Exception):
+            await h2h_league.get_fixtures()
+
+    async def test_get_fixtures_with_unknown_gameweek_authorized(
+        self, loop, mocker, h2h_league):
+        mocked_logged_in = mocker.patch(
+            "fpl.models.h2h_league.logged_in", return_value=True)
+        mocked_fetch = mocker.patch(
+            "fpl.models.h2h_league.fetch", return_value={}, new_callable=AsyncMock)
+        gameweek_number = 3
+        mocked_current_gameweek = mocker.patch(
+            "fpl.models.h2h_league.get_current_gameweek",
+            return_value=gameweek_number,
+            new_callable=AsyncMock)
         fixtures = await h2h_league.get_fixtures()
         assert isinstance(fixtures, list)
-        assert isinstance(fixtures[0], dict)
+        assert len(fixtures) == gameweek_number
+        assert mocked_fetch.call_count == gameweek_number
+        mocked_logged_in.assert_called_once()
+        mocked_current_gameweek.assert_called_once()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,30 +1,191 @@
+import aiohttp
+import pytest
+
+from fpl.models.user import User
+from tests.helper import AsyncMock
+
+user_data = {
+    "entry": {
+        "id": 3808385,
+        "player_first_name": "Amos",
+        "player_last_name": "Bastian",
+        "player_region_id": 152,
+        "player_region_name": "Netherlands",
+        "player_region_short_iso": "NL",
+        "summary_overall_points": 1621,
+        "summary_overall_rank": 22424,
+        "summary_event_points": 75,
+        "summary_event_rank": 839850,
+        "joined_seconds": 16972,
+        "current_event": 26,
+        "total_transfers": 23,
+        "total_loans": 0,
+        "total_loans_active": 0,
+        "transfers_or_loans": "transfers",
+        "deleted": False,
+        "email": False,
+        "joined_time": "2018-08-09T22:44:21Z",
+        "name": "( ͡° ͜ʖ ͡°)",
+        "bank": 43,
+        "value": 1024,
+        "kit": "{\"kit_shirt_type\":\"plain\",\"kit_shirt_base\":\"#ff0000\",\"kit_shirt_sleeves\":\"#ff0000\",\"kit_shirt_secondary\":\"#e1e1e1\",\"kit_shirt_logo\":\"none\",\"kit_shorts\":\"#000000\",\"kit_socks_type\":\"plain\",\"kit_socks_base\":\"#ffffff\",\"kit_socks_secondary\":\"#e1e1e1\"}",
+        "event_transfers": 0,
+        "event_transfers_cost": 0,
+        "extra_free_transfers": 1,
+        "strategy": None,
+        "favourite_team": 14,
+        "started_event": 1,
+        "player": 7425806
+    },
+    "leagues": {
+        "cup": [
+
+        ],
+        "h2h": [
+
+        ],
+        "classic": []
+    }
+}
+
+
+@pytest.fixture()
+async def user():
+    session = aiohttp.ClientSession()
+    yield User(user_data, session)
+    await session.close()
+
+
 class TestUser(object):
-    async def test_gameweek_history(self, loop, user):
+    async def test_init(self, loop):
+        session = aiohttp.ClientSession()
+        user = User(user_data, session)
+        assert user._session is session
+        assert user.leagues is user_data["leagues"]
+        for k, v in user_data["entry"].items():
+            assert getattr(user, k) == v
+        await session.close()
+
+    async def test_get_gameweek_history_unknown_gameweek_cached(self, loop, mocker, user):
+        user._history = {"history": [{"event": 1}, {"event": 2}, {"event": 3}]}
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value={}, new_callable=AsyncMock)
         history = await user.get_gameweek_history()
+        assert history is user._history["history"]
+        mocked_fetch.assert_not_called()
+
+    async def test_get_gameweek_history_unknown_gameweek_non_cached(self, loop, mocker, user):
+        mocked_fetch = mocker.patch("fpl.models.user.fetch",
+                                    return_value={"history": [{"event": 1}, {"event": 2}, {"event": 3}]},
+                                    new_callable=AsyncMock)
+        history = await user.get_gameweek_history()
+        mocked_fetch.assert_called_once()
         assert isinstance(history, list)
+        assert len(history) == 3
 
+    async def test_get_gameweek_history_known_gameweek_cached(self, loop, mocker, user):
+        mocked_fetch = mocker.patch("fpl.models.user.fetch",
+                                    return_value={"history": []},
+                                    new_callable=AsyncMock)
+        events = [{"event": 1}, {"event": 2}, {"event": 3}]
+        user._history = {"history": events}
         history = await user.get_gameweek_history(1)
-        assert isinstance(history, dict)
+        assert history is events[0]
+        mocked_fetch.assert_not_called()
 
-    async def test_season_history(self, loop, user):
+    async def test_get_gameweek_history_known_gameweek_non_cached(self, loop, mocker, user):
+        events = [{"event": 1}, {"event": 2}, {"event": 3}]
+        mocked_fetch = mocker.patch("fpl.models.user.fetch",
+                                    return_value={"history": events},
+                                    new_callable=AsyncMock)
+        history = await user.get_gameweek_history(1)
+        assert history is events[0]
+        mocked_fetch.assert_called_once()
+
+    async def test_get_season_history_cached(self, loop, mocker, user):
+        mocked_fetch = mocker.patch("fpl.models.user.fetch",
+                                    return_value={"season": [{"season": 5}]},
+                                    new_callable=AsyncMock)
+        seasons = [{"season": 6}]
+        user._history = {"season": seasons}
         season_history = await user.get_season_history()
-        assert isinstance(season_history, list)
+        mocked_fetch.assert_not_called()
+        assert season_history is seasons
 
-    async def test_chips_history(self, loop, user):
-        chips = await user.get_chips_history()
-        assert isinstance(chips, list)
+    async def test_get_season_history_non_cached(self, loop, mocker, user):
+        mocked_fetch = mocker.patch("fpl.models.user.fetch",
+                                    return_value={"season": [{"season": 5}]},
+                                    new_callable=AsyncMock)
+        season_history = await user.get_season_history()
+        mocked_fetch.assert_called_once()
+        assert season_history is mocked_fetch.return_value["season"]
+
+    async def test_get_chips_history_cached_with_unknown_gameweek(self, loop, mocker, user):
+        user._history = {"chips": [{"event": 1}, {"event": 2}, {"event": 3}]}
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value={}, new_callable=AsyncMock)
+        chips_history = await user.get_chips_history()
+        assert chips_history is user._history["chips"]
+        mocked_fetch.assert_not_called()
+
+    async def test_get_chips_history_non_cached_with_unknown_gameweek(self, loop, mocker, user):
+        data = {"chips": [{"event": 1}, {"event": 2}, {"event": 3}]}
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value=data, new_callable=AsyncMock)
+        chips_history = await user.get_chips_history()
+        assert chips_history is mocked_fetch.return_value["chips"]
+        mocked_fetch.assert_called_once()
+
+    async def test_get_chips_history_cached_with_known_gameweek(self, loop, mocker, user):
+        user._history = {"chips": [{"event": 1}, {"event": 2}, {"event": 3}]}
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value={}, new_callable=AsyncMock)
+        history = await user.get_chips_history(1)
+        assert history is user._history["chips"][0]
+        mocked_fetch.assert_not_called()
+
+    async def test_get_chips_history_non_cached_with_known_gameweek(self, loop, mocker, user):
+        data = {"chips": [{"event": 1}, {"event": 2}, {"event": 3}]}
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value=data, new_callable=AsyncMock)
+        chips_history = await user.get_chips_history(1)
+        assert chips_history is mocked_fetch.return_value["chips"][0]
+        mocked_fetch.assert_called_once()
 
     async def test_leagues(self, loop, user):
         leagues = user.leagues
         assert isinstance(leagues, dict)
 
-    async def test_picks(self, loop, user):
+    async def test_get_picks_cached_with_unknown_gameweek(self, loop, mocker, user):
+        picks_list = [{"element": 282}, {"element": 280}, {"element": 284}, {"element": 286}]
+        user._picks = [{"event": {"id": 1}, "picks": picks_list[:2]},
+                       {"event": {"id": 2}, "picks": picks_list[2:]}]
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value={}, new_callable=AsyncMock)
+        picks = await user.get_picks()
+        assert picks == picks_list
+        mocked_fetch.assert_not_called()
+
+    async def test_get_picks_non_cached_with_unknown_gameweek(self, loop, mocker, user):
+        picks_list = [{"element": 282}, {"element": 280}]
+        data = {"event": {"id": 1}, "picks": picks_list}
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value=data, new_callable=AsyncMock)
         picks = await user.get_picks()
         assert isinstance(picks, list)
-        assert len(picks) == user.current_event
+        assert len(picks) == user.current_event * len(picks_list)
+        assert mocked_fetch.call_count == user.current_event
 
+    async def test_get_picks_cached_with_known_gameweek(self, loop, mocker, user):
+        picks_list = [{"element": 282}, {"element": 280}, {"element": 284}, {"element": 286}]
+        user._picks = [{"event": {"id": 1}, "picks": picks_list[:2]},
+                       {"event": {"id": 2}, "picks": picks_list[2:]}]
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value={}, new_callable=AsyncMock)
+        picks = await user.get_picks(1)
+        assert picks == picks_list[:2]
+        mocked_fetch.assert_not_called()
+
+    async def test_get_picks_non_cached_with_known_gameweek(self, loop, mocker, user):
+        picks_list = [{"element": 282}, {"element": 280}]
+        data = {"event": {"id": 1}, "picks": picks_list}
+        mocked_fetch = mocker.patch("fpl.models.user.fetch", return_value=data, new_callable=AsyncMock)
         picks = await user.get_picks(1)
         assert isinstance(picks, list)
+        assert picks == picks_list
+        assert mocked_fetch.call_count == user.current_event
 
     async def test_active_chips(self, loop, user):
         active_chips = await user.get_active_chips()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -49,13 +49,6 @@ user_data = {
 }
 
 
-@pytest.fixture()
-async def user():
-    session = aiohttp.ClientSession()
-    yield User(user_data, session)
-    await session.close()
-
-
 class TestHelpers:
     def test_valid_gameweek_gameweek_out_of_range(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Running tests locally required specific credentials for `fpl.login()` method. Mocking was introduced to abstract the logic of fetching data and a few methods' logic was fixed according to the docs.