### PR TITLE
Fix user.picks hanging for users who started > gameweek 1

### DIFF
--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -210,7 +210,8 @@ class User():
             tasks = [asyncio.ensure_future(
                      fetch(self._session,
                            API_URLS["user_picks"].format(self.id, gameweek)))
-                     for gameweek in range(1, self.current_event + 1)]
+                     for gameweek in range(self.started_event,
+                                           self.current_event + 1)]
             picks = await asyncio.gather(*tasks)
             self._picks = picks
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="fpl",
-    version="0.6.5",
+    version="0.6.6",
     packages=find_packages(),
     description="A Python wrapper for the Fantasy Premier League API",
     long_description=long_description,


### PR DESCRIPTION
Now uses a user's `started_event` attribute instead of hardcoded gameweek 1.