### PR TITLE
Making quickstart code compatible with Python 3.6

### DIFF
--- a/docs/classes/fixture.rst
+++ b/docs/classes/fixture.rst
@@ -46,7 +46,13 @@ Basic usage:
           fixture = await fpl.get_fixture(3)
       print(fixture)
 
-  asyncio.get_event_loop().run_until_complete(main())
+  # Python 3.7+
+  asyncio.run(main())
+  ...
+  # Python 3.6
+  loop = asyncio.get_event_loop()
+  loop.run_until_complete(main())
+  
   # Liverpool vs. Leeds - Sat 12 Sep 16:30
 
 .. autoclass:: fpl.models.fixture.Fixture

--- a/docs/classes/fpl.rst
+++ b/docs/classes/fpl.rst
@@ -22,7 +22,12 @@ can look something like this:
 
       print(my_team)
 
-  asyncio.get_event_loop().run_until_complete(main())
+  # Python 3.7+
+  asyncio.run(main())
+  ...
+  # Python 3.6
+  loop = asyncio.get_event_loop()
+  loop.run_until_complete(main())
 
 Note that when calling the ``login`` function, you must either specify an ``email`` and ``password``,
 or set up system environment variables named ``FPL_EMAIL`` and ``FPL_PASSWORD``.

--- a/docs/classes/gameweek.rst
+++ b/docs/classes/gameweek.rst
@@ -53,7 +53,12 @@ Basic usage:
           gameweek = await fpl.get_gameweek(1)
       print(gameweek)
 
-  asyncio.get_event_loop().run_until_complete(main())
+  # Python 3.7+
+  asyncio.run(main())
+  ...
+  # Python 3.6
+  loop = asyncio.get_event_loop()
+  loop.run_until_complete(main())
   # Gameweek 1 - Deadline Sat 12 Sep 10:00
 
 .. autoclass:: fpl.models.gameweek.Gameweek

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,6 @@ A Python wrapper for the Fantasy Premier League API
 .. image:: https://travis-ci.org/amosbastian/fpl.svg?branch=master
     :target: https://travis-ci.org/amosbastian/fpl
 
-.. image:: https://img.shields.io/badge/Supported%20by-Utopian.io-%23B10DC9.svg
-    :target: https://utopian.io/
-
 .. image:: https://badge.fury.io/py/fpl.svg
     :target: https://pypi.org/project/fpl/
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ join our `Discord server <https://discord.gg/cjY37fv>`_ or send an email to
     # Python 3.7+
     asyncio.run(main())
     ...
+    # Python 3.6
     loop = asyncio.get_event_loop()
     loop.run_until_complete(main())
     Fernandes - Midfielder - Man Utd

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,12 @@ join our `Discord server <https://discord.gg/cjY37fv>`_ or send an email to
             player = await fpl.get_player(302)
         print(player)
     ...
+    # Python 3.7+
     asyncio.run(main())
+    ...
+    # Python 3.6
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
     Pogba - Midfielder - Man Utd
 
 With **fpl** you can easily use the Fantasy Premier League API in all your

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,8 @@ join our `Discord server <https://discord.gg/cjY37fv>`_ or send an email to
 With **fpl** you can easily use the Fantasy Premier League API in all your
 Python scripts, exactly how you expect it to work.
 
+.. note:: If you are using **fpl** in an environment such as a Jupyter notebook, then you might need to use `nest_asyncio` instead of `asyncio`.
+
 The User Guide
 --------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,16 +28,16 @@ join our `Discord server <https://discord.gg/cjY37fv>`_ or send an email to
 
 **A simple example**::
 
-    >>> import aiohttp
-    >>> import asyncio
-    >>> from fpl import FPL
-    >>> async def main():
-    ...     async with aiohttp.ClientSession() as session:
-    ...         fpl = FPL(session)
-    ...         player = await fpl.get_player(302)
-    ...     print(player)
+    import aiohttp
+    import asyncio
+    from fpl import FPL
+    async def main():
+        async with aiohttp.ClientSession() as session:
+            fpl = FPL(session)
+            player = await fpl.get_player(302)
+        print(player)
     ...
-    >>> asyncio.run(main())
+    asyncio.run(main())
     Pogba - Midfielder - Man Utd
 
 With **fpl** you can easily use the Fantasy Premier League API in all your

--- a/docs/user/examples.rst
+++ b/docs/user/examples.rst
@@ -52,8 +52,15 @@ to implement using **fpl**!
 
        print(player_table)
 
-   if __name__ == "__main__":
-       asyncio.run(main())
+    if __name__ == "__main__":
+        if sys.version_info >= (3, 7):
+            # Python 3.7+
+            asyncio.run(main())
+        else:
+            # Python 3.6
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(main())
+        
 
 which outputs the following table::
 
@@ -122,8 +129,14 @@ highlighting is shown::
         fdr_table.align["Team"] = "l"
         print(fdr_table)
 
-    if __name__ == '__main__':
-        asyncio.run(main())
+    if __name__ == "__main__":
+        if sys.version_info >= (3, 7):
+            # Python 3.7+
+            asyncio.run(main())
+        else:
+            # Python 3.6
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(main())
 
 
 which outputs the following table::
@@ -242,7 +255,13 @@ top scorer of each gameweek, and their respective difference in points scored::
         print(f"Total point difference is {abs(total_difference)} points!")
 
     if __name__ == '__main__':
-        asyncio.run(main(3808385))
+        if sys.version_info >= (3, 7):
+            # Python 3.7+
+            asyncio.run(main(3808385))
+        else:
+            # Python 3.6
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(main(3808385))
 
 which outputs the following table::
 

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -67,8 +67,16 @@ following::
 Nice, right? However, one important thing was left out. Because **fpl** is
 asynchronous, you must use ``asyncio`` to run the function::
 
+    import sys
     import asyncio
-    asyncio.run(main())
+    
+    if sys.version_info >= (3, 7):
+        # Python 3.7+
+        asyncio.run(main())
+    else:
+        # Python 3.6
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
 
 
 Authentication
@@ -96,6 +104,10 @@ required. Let's use my team as an example::
             user = await fpl.get_user(user_id)
             team = await user.get_team()
         print(team)
-    ...
+    # Python 3.7+
     asyncio.run(my_team(3808385))
+    ...
+    # Python 3.6
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(my_team(3808385))
     [{'can_sub': True, 'has_played': False, 'is_sub': False, 'can_captain': True, 'selling_price': 46, 'multiplier': 1, 'is_captain': False, 'is_vice_captain': False, 'position': 1, 'element': 400}, ..., {'can_sub': True, 'has_played': False, 'is_sub': True, 'can_captain': True, 'selling_price': 44, 'multiplier': 1, 'is_captain': False, 'is_vice_captain': False, 'position': 15, 'element': 201}]

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -17,32 +17,32 @@ information from the Fantasy Premier League's API.
 
 Begin by importing the :class:`FPL <fpl.FPL>` class from **fpl**::
 
-    >>> from fpl import FPL
+    from fpl import FPL
 
 Because **fpl** uses `aiohttp <https://aiohttp.readthedocs.io/en/stable/>`_,
 we must also import this and pass a `Client Session <https://docs.aiohttp.org/en/stable/client_advanced.html>`_
 as an argument to the `FPL` class. You can either create a session and pass it like this::
 
-    >>> import aiohttp
+    import aiohttp
     >>>
-    >>> async def main():
-    ...     session = aiohttp.ClientSession()
-    ...     fpl = FPL(session)
+    async def main():
+        session = aiohttp.ClientSession()
+        fpl = FPL(session)
             # ...
-    ...     await session.close()
+        await session.close()
 
 or use a session context manager::
 
-    >>> async def main():
-    ...     async with aiohttp.ClientSession as session:
-    ...         fpl = FPL(session)
-    ...         # ...
+    async def main():
+        async with aiohttp.ClientSession as session:
+            fpl = FPL(session)
+            # ...
 
 Now, let's try to get a player. For this example, let's get Manchester United's
 star midfielder Paul Pogba (replace `# ...` with this code)::
 
-    >>> player = await fpl.get_player(302)
-    >>> print(player)
+    player = await fpl.get_player(302)
+    print(player)
     Pogba - Midfielder - Man Utd
 
 Now, we have a :class:`Player <fpl.models.player.Player>` object called
@@ -50,9 +50,9 @@ Now, we have a :class:`Player <fpl.models.player.Player>` object called
 example, if we want his points per game, or his total points, then we can
 simply do this::
 
-    >>> print(player.points_per_game)
+    print(player.points_per_game)
     5.7
-    >>> print(player.total_points)
+    print(player.total_points)
     113
 
 Nearly all of :class:`FPL <fpl.FPL>`'s functions include the argument
@@ -60,15 +60,15 @@ Nearly all of :class:`FPL <fpl.FPL>`'s functions include the argument
 :class:`Player <fpl.models.player.Player>` object, then you can simply do the
 following::
 
-    >>> player = await fpl.get_player(302, return_json=True)
-    >>> print(player["total_points"])
+    player = await fpl.get_player(302, return_json=True)
+    print(player["total_points"])
     113
 
 Nice, right? However, one important thing was left out. Because **fpl** is
 asynchronous, you must use ``asyncio`` to run the function::
 
-    >>> import asyncio
-    >>> asyncio.run(main())
+    import asyncio
+    asyncio.run(main())
 
 
 Authentication
@@ -85,17 +85,17 @@ access this, the ``login`` function was added to :class:`FPL <fpl.FPL>`. It
 must be called before using other functions where login authentication is
 required. Let's use my team as an example::
 
-    >>> import asyncio
-    >>> import aiohttp
-    >>> from fpl import FPL
+    import asyncio
+    import aiohttp
+    from fpl import FPL
     >>>
-    >>> async def my_team(user_id):
-    ...     async with aiohttp.ClientSession() as session:
-    ...         fpl = FPL(session)
-    ...         await fpl.login()
-    ...         user = await fpl.get_user(user_id)
-    ...         team = await user.get_team()
-    ...     print(team)
+    async def my_team(user_id):
+        async with aiohttp.ClientSession() as session:
+            fpl = FPL(session)
+            await fpl.login()
+            user = await fpl.get_user(user_id)
+            team = await user.get_team()
+        print(team)
     ...
-    >>> asyncio.run(my_team(3808385))
+    asyncio.run(my_team(3808385))
     [{'can_sub': True, 'has_played': False, 'is_sub': False, 'can_captain': True, 'selling_price': 46, 'multiplier': 1, 'is_captain': False, 'is_vice_captain': False, 'position': 1, 'element': 400}, ..., {'can_sub': True, 'has_played': False, 'is_sub': True, 'can_captain': True, 'selling_price': 44, 'multiplier': 1, 'is_captain': False, 'is_vice_captain': False, 'position': 15, 'element': 201}]

--- a/fpl/models/classic_league.py
+++ b/fpl/models/classic_league.py
@@ -7,18 +7,18 @@ class ClassicLeague():
 
     Basic usage::
 
-      >>> from fpl import FPL
-      >>> import aiohttp
-      >>> import asyncio
+      from fpl import FPL
+      import aiohttp
+      import asyncio
       >>>
-      >>> async def main():
-      ...     async with aiohttp.ClientSession() as session:
-      ...         fpl = FPL(session)
-      ...         await fpl.login()
-      ...         classic_league = await fpl.get_classic_league(1137)
-      ...     print(classic_league)
+      async def main():
+          async with aiohttp.ClientSession() as session:
+              fpl = FPL(session)
+              await fpl.login()
+              classic_league = await fpl.get_classic_league(1137)
+          print(classic_league)
       ...
-      >>> asyncio.run(main())
+      asyncio.run(main())
       Official /r/FantasyPL Classic League - 1137
     """
     def __init__(self, league_information, session):

--- a/fpl/models/classic_league.py
+++ b/fpl/models/classic_league.py
@@ -18,7 +18,12 @@ class ClassicLeague():
               classic_league = await fpl.get_classic_league(1137)
           print(classic_league)
       ...
+      # Python 3.7+
       asyncio.run(main())
+      # Python 3.6
+      loop = asyncio.get_event_loop()
+      loop.run_until_complete(main())
+      ...
       Official /r/FantasyPL Classic League - 1137
     """
     def __init__(self, league_information, session):

--- a/fpl/models/h2h_league.py
+++ b/fpl/models/h2h_league.py
@@ -10,18 +10,18 @@ class H2HLeague():
 
     Basic usage::
 
-      >>> from fpl import FPL
-      >>> import aiohttp
-      >>> import asyncio
+      from fpl import FPL
+      import aiohttp
+      import asyncio
       >>>
-      >>> async def main():
-      ...     async with aiohttp.ClientSession() as session:
-      ...         fpl = FPL(session)
-      ...         await fpl.login()
-      ...         h2h_league = await fpl.get_h2h_league(760869)
-      ...     print(h2h_league)
+      async def main():
+          async with aiohttp.ClientSession() as session:
+              fpl = FPL(session)
+              await fpl.login()
+              h2h_league = await fpl.get_h2h_league(760869)
+          print(h2h_league)
       ...
-      >>> asyncio.run(main())
+      asyncio.run(main())
       League 760869 - 760869
     """
 

--- a/fpl/models/h2h_league.py
+++ b/fpl/models/h2h_league.py
@@ -21,7 +21,12 @@ class H2HLeague():
               h2h_league = await fpl.get_h2h_league(760869)
           print(h2h_league)
       ...
+      # Python 3.7+
       asyncio.run(main())
+      ...
+      # Python 3.6
+      loop = asyncio.get_event_loop()
+      loop.run_until_complete(main())
       League 760869 - 760869
     """
 

--- a/fpl/models/team.py
+++ b/fpl/models/team.py
@@ -18,7 +18,12 @@ class Team():
               team = await fpl.get_team(14)
           print(team)
       ...
+      # Python 3.7+
       asyncio.run(main())
+      ...
+      # Python 3.6
+      loop = asyncio.get_event_loop()
+      loop.run_until_complete(main())
       Man Utd
     """
     def __init__(self, team_information, session):

--- a/fpl/models/team.py
+++ b/fpl/models/team.py
@@ -8,17 +8,17 @@ class Team():
 
     Basic usage::
 
-      >>> from fpl import FPL
-      >>> import aiohttp
-      >>> import asyncio
+      from fpl import FPL
+      import aiohttp
+      import asyncio
       >>>
-      >>> async def main():
-      ...     async with aiohttp.ClientSession() as session:
-      ...         fpl = FPL(session)
-      ...         team = await fpl.get_team(14)
-      ...     print(team)
+      async def main():
+          async with aiohttp.ClientSession() as session:
+              fpl = FPL(session)
+              team = await fpl.get_team(14)
+          print(team)
       ...
-      >>> asyncio.run(main())
+      asyncio.run(main())
       Man Utd
     """
     def __init__(self, team_information, session):

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -106,17 +106,17 @@ def _set_captain(lineup, captain, captain_type, player_ids):
 class User():
     """A class representing a user of the Fantasy Premier League.
 
-    >>> from fpl import FPL
-      >>> import aiohttp
-      >>> import asyncio
+    from fpl import FPL
+      import aiohttp
+      import asyncio
       >>>
-      >>> async def main():
-      ...     async with aiohttp.ClientSession() as session:
-      ...         fpl = FPL(session)
-      ...         user = await fpl.get_user(3808385)
-      ...     print(user)
+      async def main():
+          async with aiohttp.ClientSession() as session:
+              fpl = FPL(session)
+              user = await fpl.get_user(3808385)
+          print(user)
       ...
-      >>> asyncio.run(main())
+      asyncio.run(main())
       Amos Bastian - Netherlands
     """
 

--- a/fpl/models/user.py
+++ b/fpl/models/user.py
@@ -106,18 +106,25 @@ def _set_captain(lineup, captain, captain_type, player_ids):
 class User():
     """A class representing a user of the Fantasy Premier League.
 
-    from fpl import FPL
-      import aiohttp
-      import asyncio
-      >>>
-      async def main():
-          async with aiohttp.ClientSession() as session:
-              fpl = FPL(session)
-              user = await fpl.get_user(3808385)
-          print(user)
-      ...
-      asyncio.run(main())
-      Amos Bastian - Netherlands
+    Basic usage::
+
+      from fpl import FPL
+        import aiohttp
+        import asyncio
+      
+        async def main():
+            async with aiohttp.ClientSession() as session:
+                fpl = FPL(session)
+                user = await fpl.get_user(3808385)
+            print(user)
+        ...
+        # Python 3.7+
+        asyncio.run(main())
+        ...
+        # Python 3.6
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
+        Amos Bastian - Netherlands
     """
 
     def __init__(self, user_information, session):


### PR DESCRIPTION
Figured I would create a pull request for #99 that I created.

I'm not sure if this is the direction to go in, or if it would be better to support Python 3.7+ or to include examples for both Python 3.6 and 3.7, but it was just a small change anyway.